### PR TITLE
Use store/tracking lingo instead of commit

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -400,6 +400,7 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
         <version>1.6.0</version>
+
       </plugin>
 
       <plugin>

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -172,8 +172,8 @@ Executors
 a new connection is open. The value must be between 1 and 255.
 |255
 
-|`maxCommittingConsumersByConnection`
-|The maximum number of `Consumer` instances that commit their offset a single connection
+|`maxTrackingConsumersByConnection`
+|The maximum number of `Consumer` instances that store their offset a single connection
 can maintain before a new connection is open. The value must be between 1 and 255.
 |50
 
@@ -644,24 +644,24 @@ The following table sums up the main settings to create a `Consumer`:
 |The consumer name (for <<consumer-offset-tracking,offset tracking>>.)
 |`null` (no offset tracking)
 
-|`AutoCommitStrategy`
-|Enable and configure the <<consumer-automatic-offset-commit,auto-commit strategy>>.
-|This is the default commit strategy if a consumer `name` is provided.
+|`AutoTrackingStrategy`
+|Enable and configure the <<consumer-automatic-offset-tracking,auto-tracking strategy>>.
+|This is the default tracking strategy if a consumer `name` is provided.
 
-|`AutoCommitStrategy#messageCountBeforeCommit`
-|Number of messages before committing.
+|`AutoTrackingStrategy#messageCountBeforeStorage`
+|Number of messages before storing.
 |10,000
 
-|`AutoCommitStrategy#flushInterval`
-|Interval to check and commit the last received offset in case of inactivity.
+|`AutoTrackingStrategy#flushInterval`
+|Interval to check and store the last received offset in case of inactivity.
 |`Duration.ofSeconds(5)`
 
-|`ManualCommitStrategy`
-|Enable and configure the <<consumer-manual-offset-commit,manual commit strategy>>.
+|`ManualTrackingStrategy`
+|Enable and configure the <<consumer-manual-offset-tracking,manual tracking strategy>>.
 |Disabled by default.
 
-|`ManualCommitStrategy#checkInterval`
-|Interval to check if the last requested committed offset has been actually committed.
+|`ManualTrackingStrategy#checkInterval`
+|Interval to check if the last requested stored offset has been actually stored.
 |`Duration.ofSeconds(5)`
 |===
 
@@ -736,108 +736,108 @@ can be any value (under 256 characters) and is expected to be unique (from the a
 point of view). Note neither the client library, nor the broker
 enforces uniqueness of the name: if 2 `Consumer` Java instances share the same name, their
 offset tracking will likely be interleaved, which applications usually do not expect.
-* the consumer must periodically *commit the offset* it has reached so far. The way
-offsets are committed depends on the commit strategy: automatic or manual.
+* the consumer must periodically *store the offset* it has reached so far. The way
+offsets are stored depends on the tracking strategy: automatic or manual.
 
-Whatever commit strategy you use, *a consumer must have a name to be able to commit offsets*.
+Whatever tracking strategy you use, *a consumer must have a name to be able to store offsets*.
 
-[[consumer-automatic-offset-commit]]
-====== Automatic Offset Commit
+[[consumer-automatic-offset-tracking]]
+====== Automatic Offset Tracking
 
-The following snippet shows how to enable automatic commit with the defaults:
+The following snippet shows how to enable automatic tracking with the defaults:
 
-.Using automatic commit strategy with the defaults
+.Using automatic tracking strategy with the defaults
 [source,java,indent=0]
 --------
-include::{test-examples}/ConsumerUsage.java[tag=auto-commit-defaults]
+include::{test-examples}/ConsumerUsage.java[tag=auto-tracking-defaults]
 --------
 <1> Set the consumer name (mandatory for offset tracking)
-<2> Use automatic commit strategy with defaults
+<2> Use automatic tracking strategy with defaults
 
-The automatic commit strategy has the following available settings:
+The automatic tracking strategy has the following available settings:
 
-* *message count before commit*: the client will commit the offset
+* *message count before storage*: the client will store the offset
 after the specified number of messages, right after the execution
 of the message handler. _The default is every 10,000 messages_.
-* *flush interval*: the client will make sure to commit the last received offset
-at the specified interval. This avoids having pending, not committed offsets in
+* *flush interval*: the client will make sure to store the last received offset
+at the specified interval. This avoids having pending, not stored offsets in
 case of inactivity. _The default is 5 seconds_.
 
 Those settings are configurable, as shown in the following snippet:
 
-.Configuring the automatic commit strategy
+.Configuring the automatic tracking strategy
 [source,java,indent=0]
 --------
-include::{test-examples}/ConsumerUsage.java[tag=auto-commit-with-settings]
+include::{test-examples}/ConsumerUsage.java[tag=auto-tracking-with-settings]
 --------
 <1> Set the consumer name (mandatory for offset tracking)
-<2> Use automatic commit strategy
-<3> Commit every 50,000 messages
-<4> Make sure to commit offset at least every 10 seconds
+<2> Use automatic tracking strategy
+<3> Store every 50,000 messages
+<4> Make sure to store offset at least every 10 seconds
 
-Note the automatic commit is the default commit strategy, so if you are fine
+Note the automatic tracking is the default tracking strategy, so if you are fine
 with its defaults, it is enabled as soon as you specify a name
 for the consumer:
 
-.Setting only the consumer name to enable automatic commit
+.Setting only the consumer name to enable automatic tracking
 [source,java,indent=0]
 --------
-include::{test-examples}/ConsumerUsage.java[tag=auto-commit-only-with-name]
+include::{test-examples}/ConsumerUsage.java[tag=auto-tracking-only-with-name]
 --------
-<1> Set only the consumer name to enable automatic commit with defaults
+<1> Set only the consumer name to enable automatic tracking with defaults
 
-Automatic commit is simple and provides good guarantees. It is nevertheless
-possible to have more fine-grained control over offset commit by using
-manual commit.
+Automatic tracking is simple and provides good guarantees. It is nevertheless
+possible to have more fine-grained control over offset tracking by using
+manual tracking.
 
-[[consumer-manual-offset-commit]]
-====== Manual Offset Commit
+[[consumer-manual-offset-tracking]]
+====== Manual Offset Tracking
 
-The manual commit strategy lets the developer in charge of committing offsets
+The manual tracking strategy lets the developer in charge of storing offsets
 whenever they want, not only after a given number of messages has been received
-and supposedly processed, like automatic commit does.
+and supposedly processed, like automatic tracking does.
 
-The following snippet shows how to enable manual commit and how to commit
+The following snippet shows how to enable manual tracking and how to store
 the offset at some point:
 
-.Using manual commit with defaults
+.Using manual tracking with defaults
 [source,java,indent=0]
 --------
-include::{test-examples}/ConsumerUsage.java[tag=manual-commit-defaults]
+include::{test-examples}/ConsumerUsage.java[tag=manual-tracking-defaults]
 --------
 <1> Set the consumer name (mandatory for offset tracking)
-<2> Use manual commit with defaults
-<3> Commit at the current offset on some condition
+<2> Use manual tracking with defaults
+<3> Store at the current offset on some condition
 
-Manual commit has only one setting: the *check interval*. The client checks
-that the last requested committed offset has been actually committed at the
+Manual tracking has only one setting: the *check interval*. The client checks
+that the last requested stored offset has been actually stored at the
 specified interval. _The default check interval is 5 seconds_.
 
-The following snippet shows the configuration of manual commit:
+The following snippet shows the configuration of manual tracking:
 
-.Configuring manual commit strategy
+.Configuring manual tracking strategy
 [source,java,indent=0]
 --------
-include::{test-examples}/ConsumerUsage.java[tag=manual-commit-with-settings]
+include::{test-examples}/ConsumerUsage.java[tag=manual-tracking-with-settings]
 --------
 <1> Set the consumer name (mandatory for offset tracking)
-<2> Use manual commit with defaults
+<2> Use manual tracking with defaults
 <3> Check last requested offset every 10 seconds
-<4> Commit at the current offset on some condition
+<4> Store the current offset on some condition
 
-The snippet above uses `MessageHandler.Context#commit()` to commit at the
-offset of the current message, but it is possible to commit anywhere
-in the stream with `MessageHandler.Context#consumer()#commit(long)` or
-simply `Consumer#commit(long)`.
+The snippet above uses `MessageHandler.Context#storeOffset()` to store at the
+offset of the current message, but it is possible to store anywhere
+in the stream with `MessageHandler.Context#consumer()#store(long)` or
+simply `Consumer#store(long)`.
 
 ====== Considerations On Offset Tracking
 
-_When to commit offsets?_ Avoid committing offsets too often or, worse, for each message.
+_When to store offsets?_ Avoid storing offsets too often or, worse, for each message.
 Even though offset tracking is a small and fast operation, it will
 make the stream grow unnecessarily, as the broker persists offset
 tracking entries in the stream itself.
 
-A good rule of thumb is to commit every few thousands
+A good rule of thumb is to store the offset every few thousands
 of messages. Of course, when the consumer will restart consuming in a new incarnation, the
 last tracked offset may be a little behind the very last message the previous incarnation
 actually processed, so the consumer may see some messages that have been already processed.
@@ -851,7 +851,7 @@ _Is the offset a reliable absolute value?_ Message offsets may not be contiguous
 This implies that the message at offset 500 in a stream may
 not be the 501 message in the stream (offsets start at 0).
 There can be different types of entries in a stream storage, a message is
-just one of them. For example, committing an offset creates an offset tracking
+just one of them. For example, storing an offset creates an offset tracking
 entry, which has its own offset.
 
 This means one must be careful when basing some decision on offset values, like

--- a/src/docs/asciidoc/performance-tool.adoc
+++ b/src/docs/asciidoc/performance-tool.adoc
@@ -386,20 +386,20 @@ an unsigned long for a given offset, and an ISO 8601 formatted timestamp
 
 A consumer can <<api.adoc#consumer-offset-tracking,track the point>> it has reached
 in a stream to be able to restart where it left off in a new incarnation.
-The performance tool has the `--commit-every` option to tell consumers to commit
+The performance tool has the `--store-every` option to tell consumers to store
 the offset every `x` messages to be able to measure the impact of offset tracking
 in terms of throughput and storage. This feature is disabled by default.
-The following command shows how to commit the offset every 100,000 messages:
+The following command shows how to store the offset every 100,000 messages:
 
 ----
-java -jar stream-perf-test.jar --commit-every 100000
+java -jar stream-perf-test.jar --store-every 100000
 ----
 
 ===== Consumer Names
 
-When using `--commit-every` (see above) for <<api.adoc#consumer-offset-tracking, offset tracking>>,
+When using `--store-every` (see above) for <<api.adoc#consumer-offset-tracking, offset tracking>>,
 the performance tool uses a default name using the pattern `{stream-name}-{consumer-number}`.
-So the default name of a single committing consumer consuming from `stream` will be `stream-1`.
+So the default name of a single tracking consumer consuming from `stream` will be `stream-1`.
 
 The consumer names pattern can be set with the `--consumer-names` option, which uses
 the https://docs.oracle.com/javase/7/docs/api/java/util/Formatter.html[Java printf-style format string].
@@ -434,10 +434,10 @@ changes for every run.
 |===
 
 Note you can use `--consumer-names uuid` to change the consumer names for every run. This
-can be useful when you want to use committing consumers in different runs but you want to
+can be useful when you want to use tracking consumers in different runs but you want to
 force the offset they start consuming from. With consumer names that do not change between runs,
-committing consumers would ignore the specified offset and would start where they left off
-(this is the purpose of offset committing).
+tracking consumers would ignore the specified offset and would start where they left off
+(this is the purpose of offset tracking).
 
 === Building the Performance Tool
 

--- a/src/main/java/com/rabbitmq/stream/Constants.java
+++ b/src/main/java/com/rabbitmq/stream/Constants.java
@@ -50,7 +50,7 @@ public final class Constants {
   public static final short COMMAND_SUBSCRIBE = 7;
   public static final short COMMAND_DELIVER = 8;
   public static final short COMMAND_CREDIT = 9;
-  public static final short COMMAND_COMMIT_OFFSET = 10;
+  public static final short COMMAND_STORE_OFFSET = 10;
   public static final short COMMAND_QUERY_OFFSET = 11;
   public static final short COMMAND_UNSUBSCRIBE = 12;
   public static final short COMMAND_CREATE_STREAM = 13;

--- a/src/main/java/com/rabbitmq/stream/Consumer.java
+++ b/src/main/java/com/rabbitmq/stream/Consumer.java
@@ -25,11 +25,11 @@ package com.rabbitmq.stream;
 public interface Consumer extends AutoCloseable {
 
   /**
-   * Commit the offset.
+   * Store the offset.
    *
    * @param offset
    */
-  void commit(long offset);
+  void store(long offset);
 
   /** Close the consumer. */
   @Override

--- a/src/main/java/com/rabbitmq/stream/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/ConsumerBuilder.java
@@ -56,20 +56,20 @@ public interface ConsumerBuilder {
   ConsumerBuilder name(String name);
 
   /**
-   * Enable {@link ManualCommitStrategy}.
+   * Enable {@link ManualTrackingStrategy}.
    *
-   * @return the manual commit strategy
+   * @return the manual tracking strategy
    */
-  ManualCommitStrategy manualCommitStrategy();
+  ManualTrackingStrategy manualTrackingStrategy();
 
   /**
-   * Enable {@link AutoCommitStrategy}.
+   * Enable {@link AutoTrackingStrategy}.
    *
-   * <p>This is the default commit strategy.
+   * <p>This is the default tracking strategy.
    *
-   * @return the auto-commit strategy
+   * @return the auto-tracking strategy
    */
-  AutoCommitStrategy autoCommitStrategy();
+  AutoTrackingStrategy autoTrackingStrategy();
 
   /**
    * Create the configured {@link Consumer}
@@ -78,18 +78,18 @@ public interface ConsumerBuilder {
    */
   Consumer build();
 
-  /** Manual commit strategy. */
-  interface ManualCommitStrategy {
+  /** Manual tracking strategy. */
+  interface ManualTrackingStrategy {
 
     /**
-     * Interval to check if the last requested committed offset has been actually committed.
+     * Interval to check if the last requested stored offset has been actually stored.
      *
      * <p>Default is 5 seconds.
      *
      * @param checkInterval
-     * @return the manual commit strategy
+     * @return the manual tracking strategy
      */
-    ManualCommitStrategy checkInterval(Duration checkInterval);
+    ManualTrackingStrategy checkInterval(Duration checkInterval);
 
     /**
      * Go back to the builder.
@@ -99,28 +99,28 @@ public interface ConsumerBuilder {
     ConsumerBuilder builder();
   }
 
-  /** Auto-commit strategy. */
-  interface AutoCommitStrategy {
+  /** Auto-tracking strategy. */
+  interface AutoTrackingStrategy {
 
     /**
-     * Number of messages before committing.
+     * Number of messages before storing.
      *
      * <p>Default is 10,000.
      *
-     * @param messageCountBeforeCommit
-     * @return the auto-commit strategy
+     * @param messageCountBeforeStorage
+     * @return the auto-tracking strategy
      */
-    AutoCommitStrategy messageCountBeforeCommit(int messageCountBeforeCommit);
+    AutoTrackingStrategy messageCountBeforeStorage(int messageCountBeforeStorage);
 
     /**
-     * Interval to check and commit the last received offset in case of inactivity.
+     * Interval to check and stored the last received offset in case of inactivity.
      *
      * <p>Default is 5 seconds.
      *
      * @param flushInterval
-     * @return the auto-commit strategy
+     * @return the auto-tracking strategy
      */
-    AutoCommitStrategy flushInterval(Duration flushInterval);
+    AutoTrackingStrategy flushInterval(Duration flushInterval);
 
     /**
      * Go back to the builder.

--- a/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
@@ -214,14 +214,14 @@ public interface EnvironmentBuilder {
   EnvironmentBuilder maxProducersByConnection(int maxProducersByConnection);
 
   /**
-   * The maximum number of committing consumers allocated to a single connection.
+   * The maximum number of tracking consumers allocated to a single connection.
    *
    * <p>Default is 50, which is the maximum value.
    *
-   * @param maxCommittingConsumersByConnection
+   * @param maxTrackingConsumersByConnection
    * @return this builder instance
    */
-  EnvironmentBuilder maxCommittingConsumersByConnection(int maxCommittingConsumersByConnection);
+  EnvironmentBuilder maxTrackingConsumersByConnection(int maxTrackingConsumersByConnection);
 
   /**
    * The maximum number of consumers allocated to a single connection.

--- a/src/main/java/com/rabbitmq/stream/MessageHandler.java
+++ b/src/main/java/com/rabbitmq/stream/MessageHandler.java
@@ -41,17 +41,17 @@ public interface MessageHandler {
     long offset();
 
     /**
-     * Shortcut to send a commit for the message offset.
+     * Shortcut to send a store order for the message offset.
      *
-     * @see Consumer#commit(long)
+     * @see Consumer#store(long)
      */
-    void commit();
+    void storeOffset();
 
     /**
      * The consumer that receives the message.
      *
      * @return
-     * @see Consumer#commit(long)
+     * @see Consumer#store(long)
      */
     Consumer consumer();
   }

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -15,7 +15,7 @@
 package com.rabbitmq.stream.impl;
 
 import static com.rabbitmq.stream.Constants.COMMAND_CLOSE;
-import static com.rabbitmq.stream.Constants.COMMAND_COMMIT_OFFSET;
+import static com.rabbitmq.stream.Constants.COMMAND_STORE_OFFSET;
 import static com.rabbitmq.stream.Constants.COMMAND_CREATE_STREAM;
 import static com.rabbitmq.stream.Constants.COMMAND_CREDIT;
 import static com.rabbitmq.stream.Constants.COMMAND_DECLARE_PUBLISHER;
@@ -1037,7 +1037,7 @@ public class Client implements AutoCloseable {
     }
   }
 
-  public void commitOffset(String reference, String stream, long offset) {
+  public void storeOffset(String reference, String stream, long offset) {
     if (reference == null || reference.isEmpty() || reference.length() > 256) {
       throw new IllegalArgumentException(
           "Reference must a non-empty string of less than 256 characters");
@@ -1048,7 +1048,7 @@ public class Client implements AutoCloseable {
     int length = 2 + 2 + 2 + reference.length() + 2 + stream.length() + 8;
     ByteBuf bb = allocate(length + 4);
     bb.writeInt(length);
-    bb.writeShort(encodeRequestCode(COMMAND_COMMIT_OFFSET));
+    bb.writeShort(encodeRequestCode(COMMAND_STORE_OFFSET));
     bb.writeShort(VERSION_1);
     bb.writeShort(reference.length());
     bb.writeBytes(reference.getBytes(StandardCharsets.UTF_8));

--- a/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
@@ -264,8 +264,8 @@ class ConsumersCoordinator {
     }
 
     @Override
-    public void commit() {
-      this.consumer.commit(this.offset);
+    public void storeOffset() {
+      this.consumer.store(this.offset);
     }
 
     @Override
@@ -615,7 +615,7 @@ class ConsumersCoordinator {
               // subscription call (not recovery), so telling the user their offset specification is
               // ignored
               LOGGER.info(
-                  "Requested offset specification {} not used in favor of committed offset found for reference {}",
+                  "Requested offset specification {} not used in favor of stored offset found for reference {}",
                   offsetSpecification,
                   offsetTrackingReference);
             }

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironmentBuilder.java
@@ -54,8 +54,8 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
       BackOffDelayPolicy.fixedWithInitialDelay(Duration.ofSeconds(5), Duration.ofSeconds(1));
   private AddressResolver addressResolver = address -> address;
   private int maxProducersByConnection = ProducersCoordinator.MAX_PRODUCERS_PER_CLIENT;
-  private int maxCommittingConsumersByConnection =
-      ProducersCoordinator.MAX_COMMITTING_CONSUMERS_PER_CLIENT;
+  private int maxTrackingConsumersByConnection =
+      ProducersCoordinator.MAX_TRACKING_CONSUMERS_PER_CLIENT;
   private int maxConsumersByConnection = ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT;
 
   public StreamEnvironmentBuilder() {}
@@ -219,16 +219,16 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
   }
 
   @Override
-  public EnvironmentBuilder maxCommittingConsumersByConnection(
-      int maxCommittingConsumersByConnection) {
-    if (maxCommittingConsumersByConnection < 1
-        || maxCommittingConsumersByConnection
-            > ProducersCoordinator.MAX_COMMITTING_CONSUMERS_PER_CLIENT) {
+  public EnvironmentBuilder maxTrackingConsumersByConnection(
+      int maxTrackingConsumersByConnection) {
+    if (maxTrackingConsumersByConnection < 1
+        || maxTrackingConsumersByConnection
+            > ProducersCoordinator.MAX_TRACKING_CONSUMERS_PER_CLIENT) {
       throw new IllegalArgumentException(
-          "maxCommittingConsumersByConnection must be between 1 and "
-              + ProducersCoordinator.MAX_COMMITTING_CONSUMERS_PER_CLIENT);
+          "maxTrackingConsumersByConnection must be between 1 and "
+              + ProducersCoordinator.MAX_TRACKING_CONSUMERS_PER_CLIENT);
     }
-    this.maxCommittingConsumersByConnection = maxCommittingConsumersByConnection;
+    this.maxTrackingConsumersByConnection = maxTrackingConsumersByConnection;
     return this;
   }
 
@@ -260,7 +260,7 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
         topologyBackOffDelayPolicy,
         addressResolver,
         maxProducersByConnection,
-        maxCommittingConsumersByConnection,
+        maxTrackingConsumersByConnection,
         maxConsumersByConnection,
         tls);
   }

--- a/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
+++ b/src/main/java/com/rabbitmq/stream/perf/StreamPerfTest.java
@@ -217,10 +217,10 @@ public class StreamPerfTest implements Callable<Integer> {
   private LeaderLocator leaderLocator;
 
   @CommandLine.Option(
-      names = {"--commit-every", "-ce"},
-      description = "the frequency of offset commit",
+      names = {"--store-every", "-se"},
+      description = "the frequency of offset storage",
       defaultValue = "0")
-  private int commitEvery;
+  private int storeEvery;
 
   @CommandLine.Option(
       names = {"--version", "-v"},
@@ -242,12 +242,11 @@ public class StreamPerfTest implements Callable<Integer> {
   private int producersByConnection;
 
   @CommandLine.Option(
-      names = {"--committing-consumers-by-connection", "-ccbc"},
-      description =
-          "number of committing consumers by connection. Value must be between 1 and 255.",
+      names = {"--tracking-consumers-by-connection", "-ccbc"},
+      description = "number of tracking consumers by connection. Value must be between 1 and 255.",
       defaultValue = "50",
       converter = Utils.OneTo255RangeIntegerTypeConverter.class)
-  private int committingConsumersByConnection;
+  private int trackingConsumersByConnection;
 
   @CommandLine.Option(
       names = {"--consumers-by-connection", "-cbc"},
@@ -422,7 +421,7 @@ public class StreamPerfTest implements Callable<Integer> {
             .scheduledExecutorService(envExecutor)
             .metricsCollector(metricsCollector)
             .maxProducersByConnection(this.producersByConnection)
-            .maxCommittingConsumersByConnection(this.committingConsumersByConnection)
+            .maxTrackingConsumersByConnection(this.trackingConsumersByConnection)
             .maxConsumersByConnection(this.consumersByConnection);
 
     if (tls) {
@@ -555,13 +554,13 @@ public class StreamPerfTest implements Callable<Integer> {
                       ConsumerBuilder consumerBuilder = environment.consumerBuilder();
                       consumerBuilder = consumerBuilder.stream(stream).offset(this.offset);
 
-                      if (this.commitEvery > 0) {
+                      if (this.storeEvery > 0) {
                         String consumerName = this.consumerNameStrategy.apply(stream, i + 1);
                         consumerBuilder =
                             consumerBuilder
                                 .name(consumerName)
-                                .autoCommitStrategy()
-                                .messageCountBeforeCommit(this.commitEvery)
+                                .autoTrackingStrategy()
+                                .messageCountBeforeStorage(this.storeEvery)
                                 .builder();
                       }
 

--- a/src/test/java/com/rabbitmq/stream/docs/ConsumerUsage.java
+++ b/src/test/java/com/rabbitmq/stream/docs/ConsumerUsage.java
@@ -16,9 +16,6 @@ package com.rabbitmq.stream.docs;
 
 import com.rabbitmq.stream.*;
 import java.time.Duration;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReference;
 
 public class ConsumerUsage {
 
@@ -37,43 +34,43 @@ public class ConsumerUsage {
         // end::producer-creation[]
     }
 
-    void defaultAutoCommit() {
+    void defaultAutoTracking() {
       Environment environment = Environment.builder().build();
-      // tag::auto-commit-defaults[]
+      // tag::auto-tracking-defaults[]
       Consumer consumer =
           environment.consumerBuilder()
               .stream("my-stream")
               .name("application-1")   // <1>
-              .autoCommitStrategy()   // <2>
+              .autoTrackingStrategy()   // <2>
               .builder()
               .messageHandler((context, message) -> {
                 // message handling code...
               })
               .build();
-      // end::auto-commit-defaults[]
+      // end::auto-tracking-defaults[]
     }
 
-  void autoCommitWithSettings() {
+  void autoTrackingWithSettings() {
     Environment environment = Environment.builder().build();
-    // tag::auto-commit-with-settings[]
+    // tag::auto-tracking-with-settings[]
     Consumer consumer =
         environment.consumerBuilder()
             .stream("my-stream")
             .name("application-1")   // <1>
-            .autoCommitStrategy()   // <2>
-                .messageCountBeforeCommit(50_000)   // <3>
+            .autoTrackingStrategy()   // <2>
+                .messageCountBeforeStorage(50_000)   // <3>
                 .flushInterval(Duration.ofSeconds(10))   // <4>
             .builder()
             .messageHandler((context, message) -> {
               // message handling code...
             })
             .build();
-    // end::auto-commit-with-settings[]
+    // end::auto-tracking-with-settings[]
   }
 
-  void autoCommitOnlyWithName() {
+  void autoTrackingOnlyWithName() {
     Environment environment = Environment.builder().build();
-    // tag::auto-commit-only-with-name[]
+    // tag::auto-tracking-only-with-name[]
     Consumer consumer =
         environment.consumerBuilder()
             .stream("my-stream")
@@ -82,52 +79,52 @@ public class ConsumerUsage {
               // message handling code...
             })
             .build();
-    // end::auto-commit-only-with-name[]
+    // end::auto-tracking-only-with-name[]
   }
 
-  void manualCommitDefaults() {
+  void manualTrackingDefaults() {
     Environment environment = Environment.builder().build();
-    // tag::manual-commit-defaults[]
+    // tag::manual-tracking-defaults[]
     Consumer consumer =
         environment.consumerBuilder()
             .stream("my-stream")
             .name("application-1")   // <1>
-            .manualCommitStrategy()   // <2>
+            .manualTrackingStrategy()   // <2>
             .builder()
             .messageHandler((context, message) -> {
               // message handling code...
 
-              if (conditionToCommit()) {
-                context.commit();   // <3>
+              if (conditionToStore()) {
+                context.storeOffset();   // <3>
               }
             })
             .build();
-    // end::manual-commit-defaults[]
+    // end::manual-tracking-defaults[]
   }
 
-  boolean conditionToCommit() {
+  boolean conditionToStore() {
       return true;
   }
 
-  void manualCommitWithSettings() {
+  void manualTrackingWithSettings() {
     Environment environment = Environment.builder().build();
-    // tag::manual-commit-with-settings[]
+    // tag::manual-tracking-with-settings[]
     Consumer consumer =
         environment.consumerBuilder()
             .stream("my-stream")
             .name("application-1")   // <1>
-            .manualCommitStrategy()   // <2>
+            .manualTrackingStrategy()   // <2>
                 .checkInterval(Duration.ofSeconds(10))   // <3>
             .builder()
             .messageHandler((context, message) -> {
               // message handling code...
 
-              if (conditionToCommit()) {
-                context.commit();   // <4>
+              if (conditionToStore()) {
+                context.storeOffset();   // <4>
               }
             })
             .build();
-    // end::manual-commit-with-settings[]
+    // end::manual-tracking-with-settings[]
   }
 
 }

--- a/src/test/java/com/rabbitmq/stream/impl/AuthorisationTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/AuthorisationTest.java
@@ -280,24 +280,24 @@ public class AuthorisationTest {
   }
 
   @Test
-  void commitQueryOffsetShouldSucceedOnAuthorisedStreamShouldFailOnUnauthorisedStream()
+  void storeQueryOffsetShouldSucceedOnAuthorisedStreamShouldFailOnUnauthorisedStream()
       throws Exception {
     Client configurationClient = configurationClient();
-    String s = "commit-not-always-authorized";
+    String s = "store-not-always-authorized";
     try {
       assertThat(configurationClient.create(s).isOk()).isTrue();
 
-      configurationClient.commitOffset("configuration", s, 10);
+      configurationClient.storeOffset("configuration", s, 10);
 
-      Duration timeToCheckOffsetCommit =
+      Duration timeToCheckOffsetTracking =
           waitAtMost(5, () -> configurationClient.queryOffset("configuration", s) == 10);
 
       Client client = client();
 
-      client.commitOffset("default-client", s, 10);
+      client.storeOffset("default-client", s, 10);
 
-      // commit offset is fire-and-forget, let's wait a bit to make sure nothing is written
-      Thread.sleep(timeToCheckOffsetCommit.toMillis() * 2);
+      // store offset is fire-and-forget, let's wait a bit to make sure nothing is written
+      Thread.sleep(timeToCheckOffsetTracking.toMillis() * 2);
       assertThat(configurationClient.queryOffset("default-client", s)).isNotEqualTo(10);
 
       // querying is not even authorised for the default client, it should return 0

--- a/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
@@ -926,7 +926,7 @@ public class ConsumersCoordinatorTest {
   @ParameterizedTest
   @MethodSource("disruptionArguments")
   @SuppressWarnings("unchecked")
-  void shouldUseCommittedOffsetOnRecovery(Consumer<ConsumersCoordinatorTest> configurator)
+  void shouldUseStoredOffsetOnRecovery(Consumer<ConsumersCoordinatorTest> configurator)
       throws Exception {
     scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
@@ -943,11 +943,11 @@ public class ConsumersCoordinatorTest {
     when(clientFactory.client(any())).thenReturn(client);
 
     String consumerName = "consumer-name";
-    long lastCommittedOffset = 5;
+    long lastStoredOffset = 5;
     long lastReceivedOffset = 10;
     when(client.queryOffset(consumerName, "stream"))
         .thenReturn((long) 0)
-        .thenReturn(lastCommittedOffset);
+        .thenReturn(lastStoredOffset);
 
     ArgumentCaptor<OffsetSpecification> offsetSpecificationArgumentCaptor =
         ArgumentCaptor.forClass(OffsetSpecification.class);
@@ -985,7 +985,7 @@ public class ConsumersCoordinatorTest {
 
     assertThat(offsetSpecificationArgumentCaptor.getAllValues())
         .element(1)
-        .isEqualTo(OffsetSpecification.offset(lastCommittedOffset + 1))
+        .isEqualTo(OffsetSpecification.offset(lastStoredOffset + 1))
         .isNotEqualTo(OffsetSpecification.offset(lastReceivedOffset));
     assertThat(subscriptionPropertiesArgumentCaptor.getAllValues())
         .element(1)

--- a/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
+++ b/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
@@ -174,19 +174,19 @@ public class MonitoringTestUtils {
   public static class ProducerManager {
 
     private final int producer_count;
-    private final int committing_consumer_count;
+    private final int tracking_consumer_count;
 
-    public ProducerManager(int producerCount, int committing_consumer_count) {
+    public ProducerManager(int producerCount, int tracking_consumer_count) {
       this.producer_count = producerCount;
-      this.committing_consumer_count = committing_consumer_count;
+      this.tracking_consumer_count = tracking_consumer_count;
     }
 
     public int getProducerCount() {
       return producer_count;
     }
 
-    public int getCommittingConsumerCount() {
-      return this.committing_consumer_count;
+    public int getTrackingConsumerCount() {
+      return this.tracking_consumer_count;
     }
 
     @Override
@@ -194,8 +194,8 @@ public class MonitoringTestUtils {
       return "ProducerManager{"
           + "producerCount="
           + producer_count
-          + ", committingConsumerCount= "
-          + committing_consumer_count
+          + ", trackingConsumerCount= "
+          + tracking_consumer_count
           + '}';
     }
   }

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentTest.java
@@ -160,8 +160,7 @@ public class StreamEnvironmentTest {
         .hasSize(1);
     assertThat(environmentInfo.getProducers().get(0).getClients().get(0).getProducerCount())
         .isEqualTo(2);
-    assertThat(
-            environmentInfo.getProducers().get(0).getClients().get(0).getCommittingConsumerCount())
+    assertThat(environmentInfo.getProducers().get(0).getClients().get(0).getTrackingConsumerCount())
         .isEqualTo(2);
     assertThat(environmentInfo.getConsumers())
         .hasSize(1)

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
@@ -77,7 +77,7 @@ public class StreamEnvironmentUnitTest {
             topologyUpdateBackOffDelayPolicy,
             host -> host,
             ProducersCoordinator.MAX_PRODUCERS_PER_CLIENT,
-            ProducersCoordinator.MAX_COMMITTING_CONSUMERS_PER_CLIENT,
+            ProducersCoordinator.MAX_TRACKING_CONSUMERS_PER_CLIENT,
             ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT,
             null,
             cf);
@@ -135,7 +135,7 @@ public class StreamEnvironmentUnitTest {
             topologyUpdateBackOffDelayPolicy,
             host -> host,
             ProducersCoordinator.MAX_PRODUCERS_PER_CLIENT,
-            ProducersCoordinator.MAX_COMMITTING_CONSUMERS_PER_CLIENT,
+            ProducersCoordinator.MAX_TRACKING_CONSUMERS_PER_CLIENT,
             ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT,
             null,
             cf);

--- a/src/test/java/com/rabbitmq/stream/perf/StreamPerfTestTest.java
+++ b/src/test/java/com/rabbitmq/stream/perf/StreamPerfTestTest.java
@@ -135,8 +135,8 @@ public class StreamPerfTestTest {
   }
 
   @Test
-  void offsetShouldBeCommittedWhenOptionIsEnabled() throws Exception {
-    Future<?> run = run(builder().commitEvery(10).consumerNames("consumer-%2$d-on-stream-%1$s"));
+  void offsetShouldBeStoredWhenOptionIsEnabled() throws Exception {
+    Future<?> run = run(builder().storeEvery(10).consumerNames("consumer-%2$d-on-stream-%1$s"));
     waitUntilStreamExists(s);
     String consumerName = "consumer-1-on-stream-" + s;
     long offset = client.queryOffset(consumerName, s);
@@ -147,7 +147,7 @@ public class StreamPerfTestTest {
   }
 
   @Test
-  void offsetShouldNotBeCommittedWhenOptionIsNotEnabled() throws Exception {
+  void offsetShouldNotBeStoredWhenOptionIsNotEnabled() throws Exception {
     Future<?> run = run(builder());
     waitUntilStreamExists(s);
     String consumerName = s + "-0"; // convention
@@ -209,8 +209,8 @@ public class StreamPerfTestTest {
       return this;
     }
 
-    ArgumentsBuilder commitEvery(int commitEvery) {
-      arguments.put("commit-every", String.valueOf(commitEvery));
+    ArgumentsBuilder storeEvery(int storeEvery) {
+      arguments.put("store-every", String.valueOf(storeEvery));
       return this;
     }
 


### PR DESCRIPTION
Commit conveys strong guarantee semantics, which can be misleading
WRT to the semantics of store_offset (asynchronous, no confirms).