### PR TITLE
Improve recovery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,8 @@
     <spotless.check.skip>true</spotless.check.skip>
     <slf4j.version>1.7.36</slf4j.version>
     <logback.version>1.2.11</logback.version>
-    <slf4j.perftool.version>2.0.3</slf4j.perftool.version>
-    <logback.perftool.version>1.3.3</logback.perftool.version>
+    <slf4j.perftool.version>2.0.6</slf4j.perftool.version>
+    <logback.perftool.version>1.3.5</logback.perftool.version>
     <netty.version>4.1.85.Final</netty.version>
     <proton-j.version>0.34.0</proton-j.version>
     <metrics.version>4.2.13</metrics.version>

--- a/src/main/java/com/rabbitmq/stream/Environment.java
+++ b/src/main/java/com/rabbitmq/stream/Environment.java
@@ -42,7 +42,7 @@ public interface Environment extends AutoCloseable {
               .getConstructor()
               .newInstance();
     } catch (Exception e) {
-      throw new StreamException(e);
+      throw new StreamException("Error while creating stream environment builder", e);
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -86,6 +86,7 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 import io.netty.channel.ChannelPromise;
+import io.netty.channel.ConnectTimeoutException;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
@@ -324,6 +325,13 @@ public class Client implements AutoCloseable {
       this.host = parameters.host;
       this.port = parameters.port;
     } catch (Exception e) {
+      if (e instanceof ConnectTimeoutException) {
+        throw new TimeoutStreamException(
+            String.format(
+                "Error while creating stream connection to %s:%d",
+                parameters.host, parameters.port),
+            e);
+      }
       throw new StreamException(e);
     }
 

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -723,6 +723,9 @@ public class Client implements AutoCloseable {
       channel.writeAndFlush(bb);
       request.block();
       return request.response.get();
+    } catch (StreamException e) {
+      outstandingRequests.remove(correlationId);
+      throw e;
     } catch (RuntimeException e) {
       outstandingRequests.remove(correlationId);
       throw new StreamException(e);
@@ -744,6 +747,9 @@ public class Client implements AutoCloseable {
       channel.writeAndFlush(bb);
       request.block();
       return request.response.get();
+    } catch (StreamException e) {
+      outstandingRequests.remove(correlationId);
+      throw e;
     } catch (RuntimeException e) {
       outstandingRequests.remove(correlationId);
       throw new StreamException(e);
@@ -2047,6 +2053,10 @@ public class Client implements AutoCloseable {
     @Override
     public int hashCode() {
       return Objects.hash(host, port);
+    }
+
+    String label() {
+      return this.host + ":" + this.port;
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/ClientProperties.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ClientProperties.java
@@ -44,7 +44,7 @@ final class ClientProperties {
               put("product", "RabbitMQ Stream");
               put("version", ClientProperties.VERSION);
               put("platform", "Java");
-              put("copyright", "Copyright (c) 2020-2021 VMware, Inc. or its affiliates.");
+              put("copyright", "Copyright (c) 2020-2022 VMware, Inc. or its affiliates.");
               put("information", "Licensed under the MPL 2.0. See https://www.rabbitmq.com/");
             }
           });

--- a/src/main/java/com/rabbitmq/stream/impl/Codecs.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Codecs.java
@@ -31,7 +31,7 @@ final class Codecs {
       return (Codec)
           Class.forName("com.rabbitmq.stream.codec.QpidProtonCodec").getConstructor().newInstance();
     } catch (Exception e) {
-      throw new StreamException(e);
+      throw new StreamException("Error while creating QPid Proton codec", e);
     }
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/CompressionCodecs.java
+++ b/src/main/java/com/rabbitmq/stream/impl/CompressionCodecs.java
@@ -33,7 +33,7 @@ class CompressionCodecs {
               .getConstructor()
               .newInstance();
     } catch (Exception e) {
-      throw new StreamException(e);
+      throw new StreamException("Error while creating compression codec factory", e);
     }
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/ConnectionStreamException.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ConnectionStreamException.java
@@ -13,13 +13,15 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
-class TimeoutStreamException extends ConnectionStreamException {
+import com.rabbitmq.stream.StreamException;
 
-  public TimeoutStreamException(String message) {
+class ConnectionStreamException extends StreamException {
+
+  public ConnectionStreamException(String message) {
     super(message);
   }
 
-  public TimeoutStreamException(String message, Throwable cause) {
+  public ConnectionStreamException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
@@ -686,8 +686,8 @@ class ConsumersCoordinator {
                 } else {
                   for (SubscriptionTracker affectedSubscription : subscriptions) {
                     ManagerPool subscriptionPool = null;
-                    boolean reassigned = false;
-                    while (!reassigned) {
+                    boolean reassignmentCompleted = false;
+                    while (!reassignmentCompleted) {
                       try {
                         if (affectedSubscription.consumer.isOpen()) {
                           Client.Broker broker = pickBroker(candidates);
@@ -715,11 +715,14 @@ class ConsumersCoordinator {
                               }
                               subscriptionPool.add(
                                   affectedSubscription, offsetSpecification, false);
-                              reassigned = true;
+                              reassignmentCompleted = true;
+                            } else {
+                              reassignmentCompleted = true;
                             }
                           }
                         } else {
                           LOGGER.debug("Not re-assigning consumer because it has been closed");
+                          reassignmentCompleted = true;
                         }
                       } catch (TimeoutStreamException e) {
                         LOGGER.debug(
@@ -740,6 +743,7 @@ class ConsumersCoordinator {
                       } catch (Exception e) {
                         LOGGER.warn(
                             "Error while re-assigning subscription from stream {}", stream, e);
+                        reassignmentCompleted = true;
                       }
                     }
                   }

--- a/src/main/java/com/rabbitmq/stream/impl/OffsetTrackingCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/OffsetTrackingCoordinator.java
@@ -13,6 +13,7 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
+import static com.rabbitmq.stream.impl.Utils.namedRunnable;
 import static com.rabbitmq.stream.impl.Utils.offsetBefore;
 
 import com.rabbitmq.stream.MessageHandler.Context;
@@ -83,36 +84,41 @@ class OffsetTrackingCoordinator {
       this.checkFuture =
           this.executor()
               .scheduleAtFixedRate(
-                  () -> {
-                    if (flushingOnGoing.compareAndSet(false, true)) {
-                      try {
-                        this.clock.setTime(System.nanoTime());
-                        Iterator<Tracker> iterator = trackers.iterator();
-                        while (iterator.hasNext()) {
-                          if (Thread.currentThread().isInterrupted()) {
-                            Thread.currentThread().interrupt();
-                            break;
-                          }
-                          Tracker t = iterator.next();
-                          if (t.consumer().isOpen()) {
-                            try {
-                              t.flushIfNecessary();
-                            } catch (Exception e) {
-                              LOGGER.info("Error while flushing tracker: {}", e.getMessage());
+                  namedRunnable(
+                      () -> {
+                        if (flushingOnGoing.compareAndSet(false, true)) {
+                          try {
+                            this.clock.setTime(System.nanoTime());
+                            LOGGER.debug(
+                                "Background offset tracking flushing, {} tracker(s) to check");
+                            Iterator<Tracker> iterator = trackers.iterator();
+                            while (iterator.hasNext()) {
+                              if (Thread.currentThread().isInterrupted()) {
+                                Thread.currentThread().interrupt();
+                                break;
+                              }
+                              Tracker t = iterator.next();
+                              if (t.consumer().isOpen()) {
+                                try {
+                                  t.flushIfNecessary();
+                                } catch (Exception e) {
+                                  LOGGER.info("Error while flushing tracker: {}", e.getMessage());
+                                }
+                              } else {
+                                iterator.remove();
+                              }
                             }
-                          } else {
-                            iterator.remove();
+                          } finally {
+                            flushingOnGoing.set(false);
                           }
+
+                          // TODO consider cancelling the task if there are no more consumers to
+                          // track
+                          // it should then be restarted on demand.
+
                         }
-                      } finally {
-                        flushingOnGoing.set(false);
-                      }
-
-                      // TODO consider cancelling the task if there are no more consumers to track
-                      // it should then be restarted on demand.
-
-                    }
-                  },
+                      },
+                      "Offset tracking background task"),
                   this.checkInterval.toMillis(),
                   this.checkInterval.toMillis(),
                   TimeUnit.MILLISECONDS);

--- a/src/main/java/com/rabbitmq/stream/impl/OffsetTrackingCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/OffsetTrackingCoordinator.java
@@ -90,7 +90,8 @@ class OffsetTrackingCoordinator {
                           try {
                             this.clock.setTime(System.nanoTime());
                             LOGGER.debug(
-                                "Background offset tracking flushing, {} tracker(s) to check");
+                                "Background offset tracking flushing, {} tracker(s) to check",
+                                this.trackers.size());
                             Iterator<Tracker> iterator = trackers.iterator();
                             while (iterator.hasNext()) {
                               if (Thread.currentThread().isInterrupted()) {

--- a/src/main/java/com/rabbitmq/stream/impl/ProducersCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ProducersCoordinator.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2022 VMware, Inc. or its affiliates.  All rights reserved.
+// Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
 // Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
@@ -13,14 +13,19 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
+import static com.rabbitmq.stream.impl.Utils.callAndMaybeRetry;
 import static com.rabbitmq.stream.impl.Utils.formatConstant;
 import static com.rabbitmq.stream.impl.Utils.namedFunction;
 import static com.rabbitmq.stream.impl.Utils.namedRunnable;
+import static java.util.stream.Collectors.toSet;
 
 import com.rabbitmq.stream.BackOffDelayPolicy;
 import com.rabbitmq.stream.Constants;
 import com.rabbitmq.stream.StreamDoesNotExistException;
 import com.rabbitmq.stream.StreamException;
+import com.rabbitmq.stream.StreamNotAvailableException;
+import com.rabbitmq.stream.impl.Client.Broker;
+import com.rabbitmq.stream.impl.Client.ClientParameters;
 import com.rabbitmq.stream.impl.Client.MetadataListener;
 import com.rabbitmq.stream.impl.Client.PublishConfirmListener;
 import com.rabbitmq.stream.impl.Client.PublishErrorListener;
@@ -30,15 +35,19 @@ import com.rabbitmq.stream.impl.Utils.ClientConnectionType;
 import com.rabbitmq.stream.impl.Utils.ClientFactory;
 import com.rabbitmq.stream.impl.Utils.ClientFactoryContext;
 import java.util.Collection;
-import java.util.List;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.NavigableSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,9 +59,11 @@ class ProducersCoordinator {
   private static final Logger LOGGER = LoggerFactory.getLogger(ProducersCoordinator.class);
   private final StreamEnvironment environment;
   private final ClientFactory clientFactory;
-  private final Map<String, ManagerPool> pools = new ConcurrentHashMap<>();
   private final int maxProducersByClient, maxTrackingConsumersByClient;
   private final Function<ClientConnectionType, String> connectionNamingStrategy;
+  private final AtomicLong managerIdSequence = new AtomicLong(0);
+  private final NavigableSet<ClientProducersManager> managers = new ConcurrentSkipListSet<>();
+  private final AtomicLong trackerIdSequence = new AtomicLong(0);
 
   ProducersCoordinator(
       StreamEnvironment environment,
@@ -67,38 +78,90 @@ class ProducersCoordinator {
     this.connectionNamingStrategy = connectionNamingStrategy;
   }
 
-  private static String keyForManagerPool(Client.Broker broker) {
-    // FIXME make sure this is a reasonable key for brokers
+  private static String keyForNode(Client.Broker broker) {
     return broker.getHost() + ":" + broker.getPort();
   }
 
   Runnable registerProducer(StreamProducer producer, String reference, String stream) {
-    return registerAgentTracker(new ProducerTracker(reference, stream, producer), stream);
+    return registerAgentTracker(
+        new ProducerTracker(trackerIdSequence.getAndIncrement(), reference, stream, producer),
+        stream);
   }
 
   Runnable registerTrackingConsumer(StreamConsumer consumer) {
     return registerAgentTracker(
-        new TrackingConsumerTracker(consumer.stream(), consumer), consumer.stream());
+        new TrackingConsumerTracker(
+            trackerIdSequence.getAndIncrement(), consumer.stream(), consumer),
+        consumer.stream());
   }
 
   private Runnable registerAgentTracker(AgentTracker tracker, String stream) {
-    Client.Broker brokerForProducer = getBrokerForProducer(stream);
+    Client.Broker broker = getBrokerForProducer(stream);
 
-    String key = keyForManagerPool(brokerForProducer);
-    ManagerPool pool =
-        pools.computeIfAbsent(
-            key,
-            s ->
-                new ManagerPool(
-                    key,
-                    environment
-                        .clientParametersCopy()
-                        .host(brokerForProducer.getHost())
-                        .port(brokerForProducer.getPort())));
-
-    pool.add(tracker);
+    addToManager(broker, tracker);
 
     return tracker::cancel;
+  }
+
+  private void addToManager(Broker node, AgentTracker tracker) {
+    ClientParameters clientParameters =
+        environment.clientParametersCopy().host(node.getHost()).port(node.getPort());
+    ClientProducersManager pickedManager = null;
+    while (pickedManager == null) {
+      Iterator<ClientProducersManager> iterator = this.managers.iterator();
+      while (iterator.hasNext()) {
+        pickedManager = iterator.next();
+        if (pickedManager.isClosed()) {
+          iterator.remove();
+          pickedManager = null;
+        } else {
+          if (node.equals(pickedManager.node) && !pickedManager.isFullFor(tracker)) {
+            // let's try this one
+            break;
+          } else {
+            pickedManager = null;
+          }
+        }
+      }
+      if (pickedManager == null) {
+        String name = keyForNode(node);
+        LOGGER.debug("Creating producer manager on {}", name);
+        pickedManager = new ClientProducersManager(node, this.clientFactory, clientParameters);
+        LOGGER.debug("Created producer manager on {}, id {}", name, pickedManager.id);
+      }
+      try {
+        pickedManager.register(tracker);
+        LOGGER.debug(
+            "Assigned tracker {} (stream '{}') to manager {} (node {}), subscription ID {}",
+            tracker.uniqueId(),
+            tracker.stream(),
+            pickedManager.id,
+            pickedManager.name,
+            tracker.identifiable() ? tracker.id() : "N/A");
+        this.managers.add(pickedManager);
+      } catch (IllegalStateException e) {
+        pickedManager = null;
+      } catch (ConnectionStreamException | ClientClosedException | StreamNotAvailableException e) {
+        // manager connection is dead or stream not available
+        // scheduling manager closing if necessary in another thread to avoid blocking this one
+        if (pickedManager.isEmpty()) {
+          ClientProducersManager manager = pickedManager;
+          this.environment.execute(
+              () -> {
+                manager.closeIfEmpty();
+              },
+              "Producer manager closing after timeout, producer %d on stream '%s'",
+              tracker.uniqueId(),
+              tracker.stream());
+        }
+        throw e;
+      } catch (RuntimeException e) {
+        if (pickedManager != null) {
+          pickedManager.closeIfEmpty();
+        }
+        throw e;
+      }
+    }
   }
 
   private Client.Broker getBrokerForProducer(String stream) {
@@ -130,44 +193,80 @@ class ProducersCoordinator {
   }
 
   void close() {
-    for (ManagerPool pool : pools.values()) {
-      pool.close();
+    Iterator<ClientProducersManager> iterator = this.managers.iterator();
+    while (iterator.hasNext()) {
+      ClientProducersManager manager = iterator.next();
+      try {
+        iterator.remove();
+        manager.close();
+      } catch (Exception e) {
+        LOGGER.info(
+            "Error while closing manager {} connected to node {}: {}",
+            manager.id,
+            manager.name,
+            e.getMessage());
+      }
     }
-    pools.clear();
-  }
-
-  int poolSize() {
-    return pools.size();
   }
 
   int clientCount() {
-    return pools.values().stream().map(pool -> pool.managers.size()).reduce(0, Integer::sum);
+    return this.managers.size();
+  }
+
+  int nodesConnected() {
+    return this.managers.stream().map(m -> m.name).collect(toSet()).size();
+  }
+
+  private static String quote(String value) {
+    if (value == null) {
+      return "null";
+    } else {
+      return "\"" + value + "\"";
+    }
+  }
+
+  private static String jsonField(String name, Number value) {
+    return quote(name) + " : " + value.longValue();
+  }
+
+  private static String jsonField(String name, String value) {
+    return quote(name) + " : " + quote(value);
   }
 
   @Override
   public String toString() {
-    return ("[ \n"
-        + pools.entrySet().stream()
+    StringBuilder builder = new StringBuilder("{");
+    builder.append(jsonField("client_count", this.managers.size())).append(",");
+    builder
+        .append(
+            jsonField(
+                "producer_count", this.managers.stream().mapToInt(m -> m.producers.size()).sum()))
+        .append(",");
+    builder
+        .append(
+            jsonField(
+                "tracking_consumer_count",
+                this.managers.stream().mapToInt(m -> m.trackingConsumerTrackers.size()).sum()))
+        .append(",");
+    builder.append(quote("clients")).append(" : [");
+    builder.append(
+        this.managers.stream()
             .map(
-                poolEntry ->
-                    "  { \"broker\" : \""
-                        + poolEntry.getKey()
-                        + "\", \"client_count\" : "
-                        + poolEntry.getValue().managers.size()
-                        + ", \"clients\" : [ "
-                        + poolEntry.getValue().managers.stream()
-                            .map(
-                                manager ->
-                                    "{ \"producer_count\" : "
-                                        + manager.producers.size()
-                                        + ", "
-                                        + "  \"tracking_consumer_count\" : "
-                                        + manager.trackingConsumerTrackers.size()
-                                        + " }")
-                            .collect(Collectors.joining(", "))
-                        + " ] }")
-            .collect(Collectors.joining(", \n"))
-        + "\n]");
+                m -> {
+                  StringBuilder b = new StringBuilder("{");
+                  b.append(jsonField("id", m.id))
+                      .append(",")
+                      .append(jsonField("node", m.name))
+                      .append(",")
+                      .append(jsonField("producer_count", m.producers.size()))
+                      .append(",")
+                      .append(
+                          jsonField("tracking_consumer_count", m.trackingConsumerTrackers.size()));
+                  return b.append("}").toString();
+                })
+            .collect(Collectors.joining(",")));
+    builder.append("]");
+    return builder.append("}").toString();
   }
 
   private interface AgentTracker {
@@ -191,17 +290,27 @@ class ProducersCoordinator {
     String reference();
 
     boolean isOpen();
+
+    long uniqueId();
+
+    String type();
+
+    boolean markRecoveryInProgress();
   }
 
   private static class ProducerTracker implements AgentTracker {
 
+    private final long uniqueId;
     private final String reference;
     private final String stream;
     private final StreamProducer producer;
     private volatile byte publisherId;
     private volatile ClientProducersManager clientProducersManager;
+    private final AtomicBoolean recovering = new AtomicBoolean(false);
 
-    private ProducerTracker(String reference, String stream, StreamProducer producer) {
+    private ProducerTracker(
+        long uniqueId, String reference, String stream, StreamProducer producer) {
+      this.uniqueId = uniqueId;
       this.reference = reference;
       this.stream = stream;
       this.producer = producer;
@@ -248,6 +357,7 @@ class ProducersCoordinator {
     @Override
     public void running() {
       this.producer.running();
+      this.recovering.set(false);
     }
 
     @Override
@@ -266,15 +376,33 @@ class ProducersCoordinator {
     public boolean isOpen() {
       return producer.isOpen();
     }
+
+    @Override
+    public long uniqueId() {
+      return this.uniqueId;
+    }
+
+    @Override
+    public String type() {
+      return "producer";
+    }
+
+    @Override
+    public boolean markRecoveryInProgress() {
+      return this.recovering.compareAndSet(false, true);
+    }
   }
 
   private static class TrackingConsumerTracker implements AgentTracker {
 
+    private final long uniqueId;
     private final String stream;
     private final StreamConsumer consumer;
     private volatile ClientProducersManager clientProducersManager;
+    private final AtomicBoolean recovering = new AtomicBoolean(false);
 
-    private TrackingConsumerTracker(String stream, StreamConsumer consumer) {
+    private TrackingConsumerTracker(long uniqueId, String stream, StreamConsumer consumer) {
+      this.uniqueId = uniqueId;
       this.stream = stream;
       this.consumer = consumer;
     }
@@ -318,6 +446,7 @@ class ProducersCoordinator {
     @Override
     public void running() {
       this.consumer.running();
+      this.recovering.set(false);
     }
 
     @Override
@@ -337,78 +466,41 @@ class ProducersCoordinator {
     public boolean isOpen() {
       return this.consumer.isOpen();
     }
+
+    @Override
+    public long uniqueId() {
+      return this.uniqueId;
+    }
+
+    @Override
+    public String type() {
+      return "tracking consumer";
+    }
+
+    @Override
+    public boolean markRecoveryInProgress() {
+      return this.recovering.compareAndSet(false, true);
+    }
   }
 
-  private class ManagerPool {
+  private class ClientProducersManager implements Comparable<ClientProducersManager> {
 
-    private final List<ClientProducersManager> managers = new CopyOnWriteArrayList<>();
+    private final long id;
     private final String name;
-    private final Client.ClientParameters clientParameters;
-
-    private ManagerPool(String name, Client.ClientParameters clientParameters) {
-      this.name = name;
-      this.clientParameters = clientParameters;
-      this.managers.add(new ClientProducersManager(this, clientFactory, clientParameters));
-    }
-
-    private synchronized void add(AgentTracker producerTracker) {
-      boolean added = false;
-      // FIXME deal with state unavailability (state may be closing because of connection closing)
-      // try all of them until it succeeds, throw exception if failure
-      for (ClientProducersManager manager : this.managers) {
-        if (!manager.isFullFor(producerTracker)) {
-          manager.register(producerTracker);
-          added = true;
-          break;
-        }
-      }
-      if (!added) {
-        LOGGER.debug(
-            "Creating producers tracker on {}, this is subscription state #{}",
-            name,
-            managers.size() + 1);
-        ClientProducersManager manager =
-            new ClientProducersManager(this, clientFactory, clientParameters);
-        this.managers.add(manager);
-        manager.register(producerTracker);
-      }
-    }
-
-    synchronized void maybeDisposeManager(ClientProducersManager manager) {
-      if (manager.isEmpty()) {
-        manager.close();
-        this.remove(manager);
-      }
-    }
-
-    private synchronized void remove(ClientProducersManager manager) {
-      this.managers.remove(manager);
-      if (this.managers.isEmpty()) {
-        pools.remove(this.name);
-      }
-    }
-
-    synchronized void close() {
-      for (ClientProducersManager manager : managers) {
-        manager.close();
-      }
-      managers.clear();
-    }
-  }
-
-  private class ClientProducersManager {
-
+    private final Broker node;
     private final ConcurrentMap<Byte, ProducerTracker> producers =
         new ConcurrentHashMap<>(maxProducersByClient);
     private final Set<AgentTracker> trackingConsumerTrackers =
         ConcurrentHashMap.newKeySet(maxTrackingConsumersByClient);
     private final Map<String, Set<AgentTracker>> streamToTrackers = new ConcurrentHashMap<>();
     private final Client client;
-    private final ManagerPool owner;
+    private final AtomicBoolean closed = new AtomicBoolean(false);
 
     private ClientProducersManager(
-        ManagerPool owner, ClientFactory cf, Client.ClientParameters clientParameters) {
-      this.owner = owner;
+        Broker node, ClientFactory cf, Client.ClientParameters clientParameters) {
+      this.id = managerIdSequence.getAndIncrement();
+      this.name = keyForNode(node);
+      this.node = node;
       AtomicReference<Client> ref = new AtomicReference<>();
       AtomicBoolean clientInitializedInManager = new AtomicBoolean(false);
       PublishConfirmListener publishConfirmListener =
@@ -434,11 +526,7 @@ class ProducersCoordinator {
           };
       ShutdownListener shutdownListener =
           shutdownContext -> {
-            // we may be closing the client because it's not the right node, so the manager
-            // should not be removed from its pool, because it's not really in it already
-            if (clientInitializedInManager.get()) {
-              owner.remove(this);
-            }
+            managers.remove(this);
             if (shutdownContext.isShutdownUnexpected()) {
               LOGGER.debug(
                   "Recovering {} producer(s) after unexpected connection termination",
@@ -463,13 +551,20 @@ class ProducersCoordinator {
                                 });
                           },
                           "Producer recovery after disconnection from %s",
-                          owner.name));
+                          name));
             }
           };
       MetadataListener metadataListener =
           (stream, code) -> {
+            LOGGER.debug(
+                "Received metadata notification for '{}', stream is likely to have become unavailable",
+                stream);
+            Set<AgentTracker> affectedTrackers;
             synchronized (ClientProducersManager.this) {
-              Set<AgentTracker> affectedTrackers = streamToTrackers.remove(stream);
+              affectedTrackers = streamToTrackers.remove(stream);
+              LOGGER.debug(
+                  "Affected publishers and consumer trackers after metadata update: {}",
+                  affectedTrackers.size());
               if (affectedTrackers != null && !affectedTrackers.isEmpty()) {
                 affectedTrackers.forEach(
                     tracker -> {
@@ -480,25 +575,27 @@ class ProducersCoordinator {
                         trackingConsumerTrackers.remove(tracker);
                       }
                     });
-                environment
-                    .scheduledExecutorService()
-                    .execute(
-                        namedRunnable(
-                            () -> {
-                              if (Thread.currentThread().isInterrupted()) {
-                                return;
-                              }
-                              // close manager if no more trackers for it
-                              // needs to be done in another thread than the IO thread
-                              this.owner.maybeDisposeManager(this);
-                              assignProducersToNewManagers(
-                                  affectedTrackers,
-                                  stream,
-                                  environment.topologyUpdateBackOffDelayPolicy());
-                            },
-                            "Producer re-assignment after metadata update on stream '%s'",
-                            stream));
               }
+            }
+            if (affectedTrackers != null && !affectedTrackers.isEmpty()) {
+              environment
+                  .scheduledExecutorService()
+                  .execute(
+                      namedRunnable(
+                          () -> {
+                            if (Thread.currentThread().isInterrupted()) {
+                              return;
+                            }
+                            // close manager if no more trackers for it
+                            // needs to be done in another thread than the IO thread
+                            closeIfEmpty();
+                            assignProducersToNewManagers(
+                                affectedTrackers,
+                                stream,
+                                environment.topologyUpdateBackOffDelayPolicy());
+                          },
+                          "Producer re-assignment after metadata update on stream '%s'",
+                          stream));
             }
           };
       String connectionName = connectionNamingStrategy.apply(ClientConnectionType.PRODUCER);
@@ -510,7 +607,7 @@ class ProducersCoordinator {
                       .shutdownListener(shutdownListener)
                       .metadataListener(metadataListener)
                       .clientProperty("connection_name", connectionName))
-              .key(owner.name);
+              .key(name);
       this.client = cf.client(connectionFactoryContext);
       LOGGER.debug("Created producer connection '{}'", connectionName);
       clientInitializedInManager.set(true);
@@ -527,48 +624,21 @@ class ProducersCoordinator {
           .build()
           .thenAccept(
               broker -> {
-                String key = keyForManagerPool(broker);
+                String key = keyForNode(broker);
                 LOGGER.debug("Assigning {} producer(s) to {}", trackers.size(), key);
-
                 trackers.forEach(
                     tracker -> {
-                      try {
-                        if (tracker.isOpen()) {
-                          // we create the pool only if necessary
-                          ManagerPool pool =
-                              pools.computeIfAbsent(
-                                  key,
-                                  s ->
-                                      new ManagerPool(
-                                          key,
-                                          environment
-                                              .clientParametersCopy()
-                                              .host(broker.getHost())
-                                              .port(broker.getPort())));
-                          pool.add(tracker);
-                          tracker.running();
-                        } else {
-                          LOGGER.debug("Not re-assigning producer because it has been closed");
-                        }
-                      } catch (Exception e) {
-                        LOGGER.info(
-                            "Error while re-assigning producer {} to {}: {}. Moving on.",
-                            tracker.identifiable() ? tracker.id() : "(tracking consumer)",
-                            key,
-                            e.getMessage());
+                      if (tracker.markRecoveryInProgress()) {
+                        recoverAgent(broker, tracker);
                       }
                     });
               })
           .exceptionally(
               ex -> {
-                LOGGER.info("Error while re-assigning producers: {}", ex.getMessage());
+                LOGGER.info(
+                    "Error while re-assigning producers and consumer trackers, closing them: {}",
+                    ex.getMessage());
                 for (AgentTracker tracker : trackers) {
-                  // FIXME what to do with tracking consumers after a timeout?
-                  // here they are left as "unavailable" and not, meaning they will not be
-                  // able to store. Yet recovery mechanism could try to reconnect them, but
-                  // that seems far-fetched (the first recovery already failed). They could
-                  // be put in a state whereby they refuse all new store commands and inform
-                  // with an exception they should be restarted.
                   try {
                     short code;
                     if (ex instanceof StreamDoesNotExistException
@@ -586,15 +656,70 @@ class ProducersCoordinator {
               });
     }
 
+    private void recoverAgent(Broker node, AgentTracker tracker) {
+      boolean reassignmentCompleted = false;
+      while (!reassignmentCompleted) {
+        try {
+          if (tracker.isOpen()) {
+            LOGGER.debug(
+                "Using {} to resume {} to {}", node.label(), tracker.type(), tracker.stream());
+            addToManager(node, tracker);
+            tracker.running();
+          } else {
+            LOGGER.debug("Not recovering {} because it has been closed", tracker.type());
+          }
+          reassignmentCompleted = true;
+        } catch (ConnectionStreamException
+            | ClientClosedException
+            | StreamNotAvailableException e) {
+          LOGGER.debug(
+              "{} re-assignment on stream {} timed out or connection closed or stream not available, "
+                  + "refreshing candidate leader and retrying",
+              tracker.type(),
+              tracker.id(),
+              tracker.stream());
+          // maybe not a good candidate, let's refresh and retry for this one
+          node =
+              Utils.callAndMaybeRetry(
+                  () -> getBrokerForProducer(tracker.stream()),
+                  ex -> !(ex instanceof StreamDoesNotExistException),
+                  environment.recoveryBackOffDelayPolicy(),
+                  "Candidate lookup for %s on stream '%s'",
+                  tracker.type(),
+                  tracker.stream());
+        } catch (Exception e) {
+          LOGGER.warn(
+              "Error while re-assigning %s (stream '{}')", tracker.type(), tracker.stream(), e);
+          reassignmentCompleted = true;
+        }
+      }
+    }
+
     private synchronized void register(AgentTracker tracker) {
+      if (this.isFullFor(tracker)) {
+        throw new IllegalStateException("Cannot add subscription tracker, the manager is full");
+      }
+      if (this.isClosed()) {
+        throw new IllegalStateException("Cannot add subscription tracker, the manager is closed");
+      }
+      checkNotClosed();
       if (tracker.identifiable()) {
         ProducerTracker producerTracker = (ProducerTracker) tracker;
         // using the next available slot
         for (int i = 0; i < maxProducersByClient; i++) {
           ProducerTracker previousValue = producers.putIfAbsent((byte) i, producerTracker);
           if (previousValue == null) {
+            this.checkNotClosed();
+            int index = i;
             Response response =
-                this.client.declarePublisher((byte) i, tracker.reference(), tracker.stream());
+                callAndMaybeRetry(
+                    () ->
+                        this.client.declarePublisher(
+                            (byte) index, tracker.reference(), tracker.stream()),
+                    RETRY_ON_TIMEOUT,
+                    "Declare publisher request for publisher %d on stream '%s'",
+                    producerTracker.uniqueId(),
+                    producerTracker.stream());
             if (response.isOk()) {
               tracker.assign((byte) i, this.client, this);
             } else {
@@ -613,13 +738,14 @@ class ProducersCoordinator {
         tracker.assign((byte) 0, this.client, this);
         trackingConsumerTrackers.add(tracker);
       }
-
       streamToTrackers
           .computeIfAbsent(tracker.stream(), s -> ConcurrentHashMap.newKeySet())
           .add(tracker);
     }
 
     private synchronized void unregister(AgentTracker tracker) {
+      LOGGER.debug(
+          "Unregistering {} {} from manager on {}", tracker.type(), tracker.uniqueId(), this.name);
       if (tracker.identifiable()) {
         producers.remove(tracker.id());
       } else {
@@ -636,7 +762,7 @@ class ProducersCoordinator {
               return trackersForThisStream.isEmpty() ? null : trackersForThisStream;
             }
           });
-      this.owner.maybeDisposeManager(this);
+      closeIfEmpty();
     }
 
     synchronized boolean isFullFor(AgentTracker tracker) {
@@ -651,14 +777,74 @@ class ProducersCoordinator {
       return producers.isEmpty() && trackingConsumerTrackers.isEmpty();
     }
 
-    private void close() {
-      try {
-        if (this.client.isOpen()) {
-          this.client.close();
-        }
-      } catch (Exception e) {
-        // ok
+    private void checkNotClosed() {
+      if (!this.client.isOpen()) {
+        throw new ClientClosedException();
       }
+    }
+
+    boolean isClosed() {
+      if (!this.client.isOpen()) {
+        this.close();
+      }
+      return this.closed.get();
+    }
+
+    private void closeIfEmpty() {
+      if (!closed.get()) {
+        synchronized (this) {
+          if (this.isEmpty()) {
+            this.close();
+          } else {
+            LOGGER.debug("Not closing producer manager {} because it is not empty", this.id);
+          }
+        }
+      }
+    }
+
+    private void close() {
+      if (closed.compareAndSet(false, true)) {
+        managers.remove(this);
+        try {
+          if (this.client.isOpen()) {
+            this.client.close();
+          }
+        } catch (Exception e) {
+          LOGGER.debug("Error while closing client producer connection: ", e.getMessage());
+        }
+      }
+    }
+
+    @Override
+    public int compareTo(ClientProducersManager o) {
+      return Long.compare(this.id, o.id);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      ClientProducersManager that = (ClientProducersManager) o;
+      return id == that.id;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(id);
+    }
+  }
+
+  private static final Predicate<Exception> RETRY_ON_TIMEOUT =
+      e -> e instanceof TimeoutStreamException;
+
+  private static class ClientClosedException extends StreamException {
+
+    public ClientClosedException() {
+      super("Client already closed");
     }
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/ScheduledExecutorServiceWrapper.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ScheduledExecutorServiceWrapper.java
@@ -1,0 +1,235 @@
+// Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import io.micrometer.core.instrument.util.NamedThreadFactory;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class ScheduledExecutorServiceWrapper implements ScheduledExecutorService {
+
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(ScheduledExecutorServiceWrapper.class);
+  private final ScheduledExecutorService delegate;
+  private final Set<Task> tasks = ConcurrentHashMap.newKeySet();
+  private final ScheduledExecutorService scheduler =
+      Executors.newSingleThreadScheduledExecutor(
+          new NamedThreadFactory("rabbitmq-stream-scheduled-executor-service-wrapper-"));
+
+  ScheduledExecutorServiceWrapper(ScheduledExecutorService delegate) {
+    this.delegate = delegate;
+    Duration period = Duration.ofSeconds(10);
+    this.scheduler.scheduleAtFixedRate(
+        () -> {
+          LOGGER.debug("Background scheduled task check, {} task(s) submitted", this.tasks.size());
+          try {
+            long now = System.nanoTime();
+            Duration warningTimeout = Duration.ofSeconds(60);
+            int cleanedCount = 0;
+            Iterator<Task> iterator = this.tasks.iterator();
+            while (iterator.hasNext()) {
+              Task task = iterator.next();
+              if (task.isCompleted()) {
+                iterator.remove();
+                cleanedCount++;
+              } else {
+                Duration elapsed = task.elapsedTime(now);
+                if (elapsed.compareTo(warningTimeout) > 0) {
+                  LOGGER.debug(
+                      "Warning: task {} has been running for {} second(s)",
+                      task.description,
+                      elapsed.getSeconds());
+                }
+              }
+            }
+            LOGGER.debug("{} completed task(s) cleaned", cleanedCount);
+          } catch (Exception e) {
+            LOGGER.debug("Error during background scheduled task check", e.getMessage());
+          }
+        },
+        period.toMillis(),
+        period.toMillis(),
+        TimeUnit.MILLISECONDS);
+  }
+
+  private void task(Runnable command, Future<?> future) {
+    task(command.toString(), future);
+  }
+
+  private void task(Callable<?> callable, Future<?> future) {
+    task(callable.toString(), future);
+  }
+
+  private void task(String description, Future<?> future) {
+    this.tasks.add(new Task(description, future));
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+    ScheduledFuture<?> future = this.delegate.schedule(command, delay, unit);
+    task(command, future);
+    return future;
+  }
+
+  @Override
+  public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+    ScheduledFuture<V> future = this.delegate.schedule(callable, delay, unit);
+    task(callable, future);
+    return future;
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(
+      Runnable command, long initialDelay, long period, TimeUnit unit) {
+    // we don't track these, because they are expected to run for a long time
+    LOGGER.debug("Registering scheduled at fixed rate task '%s'", command.toString());
+    return this.delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(
+      Runnable command, long initialDelay, long delay, TimeUnit unit) {
+    // we don't track these, because they are expected to run for a long time
+    LOGGER.debug("Registering scheduled with fixed delay task '%s'", command.toString());
+    return this.delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+  }
+
+  @Override
+  public void shutdown() {
+    this.delegate.shutdown();
+  }
+
+  @Override
+  public List<Runnable> shutdownNow() {
+    return this.delegate.shutdownNow();
+  }
+
+  @Override
+  public boolean isShutdown() {
+    return this.delegate.isShutdown();
+  }
+
+  @Override
+  public boolean isTerminated() {
+    return this.delegate.isTerminated();
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    return this.delegate.awaitTermination(timeout, unit);
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    Future<T> future = this.delegate.submit(task);
+    task(task, future);
+    return future;
+  }
+
+  @Override
+  public <T> Future<T> submit(Runnable task, T result) {
+    Future<T> future = this.delegate.submit(task, result);
+    task(task, future);
+    return future;
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    Future<?> future = this.delegate.submit(task);
+    task(task, future);
+    return future;
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks)
+      throws InterruptedException {
+    List<? extends Callable<T>> taskList = new ArrayList<>(tasks);
+    List<Future<T>> futures = this.delegate.invokeAll(taskList);
+    for (int i = 0; i < taskList.size(); i++) {
+      task(taskList.get(i), futures.get(i));
+    }
+    return futures;
+  }
+
+  @Override
+  public <T> List<Future<T>> invokeAll(
+      Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+      throws InterruptedException {
+    List<? extends Callable<T>> taskList = new ArrayList<>(tasks);
+    List<Future<T>> futures = this.delegate.invokeAll(taskList, timeout, unit);
+    for (int i = 0; i < taskList.size(); i++) {
+      task(taskList.get(i), futures.get(i));
+    }
+    return futures;
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void execute(Runnable command) {
+    Callable<Void> callable =
+        () -> {
+          command.run();
+          return null;
+        };
+    Future<Void> future = this.delegate.submit(callable);
+    task(command, future);
+  }
+
+  static class Task {
+
+    private final Future<?> future;
+    private final String description;
+    private final long start;
+
+    Task(String description, Future<?> future) {
+      this.description = description;
+      this.future = future;
+      this.start = System.nanoTime();
+    }
+
+    boolean isCompleted() {
+      return this.future.isDone();
+    }
+
+    Duration elapsedTime(long now) {
+      if (now - start < 0) {
+        return Duration.ZERO;
+      } else {
+        return Duration.ofNanos(now - start);
+      }
+    }
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/impl/ScheduledExecutorServiceWrapper.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ScheduledExecutorServiceWrapper.java
@@ -106,7 +106,7 @@ class ScheduledExecutorServiceWrapper implements ScheduledExecutorService {
   public ScheduledFuture<?> scheduleAtFixedRate(
       Runnable command, long initialDelay, long period, TimeUnit unit) {
     // we don't track these, because they are expected to run for a long time
-    LOGGER.debug("Registering scheduled at fixed rate task '%s'", command.toString());
+    LOGGER.debug("Registering scheduled at fixed rate task '{}'", command.toString());
     return this.delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -812,6 +812,10 @@ class StreamEnvironment implements Environment {
                 })
             .collect(Collectors.joining(","))
         + "], "
+        + Utils.jsonField("producer_client_count", this.producersCoordinator.clientCount())
+        + ","
+        + Utils.jsonField("consumer_client_count", this.consumersCoordinator.managerCount())
+        + ","
         + "\"producers\" : "
         + this.producersCoordinator
         + ", \"consumers\" : "

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -211,6 +211,7 @@ class StreamEnvironment implements Environment {
       executorService = scheduledExecutorService;
       this.privateScheduleExecutorService = false;
     }
+    // TODO remove executor wrapper (it's here just for debugging)
     this.scheduledExecutorService = new ScheduledExecutorServiceWrapper(executorService);
 
     this.producersCoordinator =

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -13,9 +13,9 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
+import static com.rabbitmq.stream.impl.Utils.convertCodeToException;
 import static com.rabbitmq.stream.impl.Utils.formatConstant;
 import static com.rabbitmq.stream.impl.Utils.namedRunnable;
-import static com.rabbitmq.stream.impl.Utils.propagateException;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.rabbitmq.stream.Address;
@@ -516,7 +516,13 @@ class StreamEnvironment implements Environment {
               "committed_chunk_id", "No committed chunk ID for stream " + stream);
       return new DefaultStreamStats(firstOffsetSupplier, committedOffsetSupplier);
     } else {
-      throw propagateException(response.getResponseCode(), stream);
+      throw convertCodeToException(
+          response.getResponseCode(),
+          stream,
+          () ->
+              "Error while querying stream info: "
+                  + formatConstant(response.getResponseCode())
+                  + ".");
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -695,7 +695,13 @@ class StreamEnvironment implements Environment {
     long start = System.nanoTime();
     while (attempt < maxAttempt) {
       try {
-        result = operation.apply(clientSupplier.get());
+        Client client = clientSupplier.get();
+        LOGGER.debug(
+            "Using locator on {}:{} to run operation '{}'",
+            client.getHost(),
+            client.getPort(),
+            operation);
+        result = operation.apply(client);
         LOGGER.debug(
             "Locator operation '{}' succeeded in {}",
             operation,

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -14,6 +14,7 @@
 package com.rabbitmq.stream.impl;
 
 import static com.rabbitmq.stream.impl.Utils.convertCodeToException;
+import static com.rabbitmq.stream.impl.Utils.exceptionMessage;
 import static com.rabbitmq.stream.impl.Utils.formatConstant;
 import static com.rabbitmq.stream.impl.Utils.namedRunnable;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -725,7 +726,7 @@ class StreamEnvironment implements Environment {
           break;
         }
       } catch (Exception e) {
-        LOGGER.debug("Exception during locator operation '{}': {}", operation, e.getMessage());
+        LOGGER.debug("Exception during locator operation '{}': {}", operation, exceptionMessage(e));
         lastException = e;
         break;
       }

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -14,6 +14,7 @@
 package com.rabbitmq.stream.impl;
 
 import static com.rabbitmq.stream.impl.Utils.formatConstant;
+import static com.rabbitmq.stream.impl.Utils.namedRunnable;
 import static com.rabbitmq.stream.impl.Utils.propagateException;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
@@ -34,6 +35,7 @@ import com.rabbitmq.stream.StreamStats;
 import com.rabbitmq.stream.SubscriptionListener;
 import com.rabbitmq.stream.compression.CompressionCodecFactory;
 import com.rabbitmq.stream.impl.Client.ClientParameters;
+import com.rabbitmq.stream.impl.Client.ShutdownListener;
 import com.rabbitmq.stream.impl.Client.StreamStatsResponse;
 import com.rabbitmq.stream.impl.OffsetTrackingCoordinator.Registration;
 import com.rabbitmq.stream.impl.StreamConsumerBuilder.TrackingConfiguration;
@@ -47,10 +49,11 @@ import io.netty.handler.ssl.SslContextBuilder;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLDecoder;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
+import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
@@ -74,8 +77,6 @@ class StreamEnvironment implements Environment {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamEnvironment.class);
 
-  private final Random random = new Random();
-
   private final EventLoopGroup eventLoopGroup;
   private final ScheduledExecutorService scheduledExecutorService;
   private final boolean privateScheduleExecutorService;
@@ -94,9 +95,9 @@ class StreamEnvironment implements Environment {
   private final Clock clock = new Clock();
   private final ScheduledFuture<?> clockRefreshFuture;
   private final ByteBufAllocator byteBufAllocator;
-  private final AtomicBoolean locatorInitialized = new AtomicBoolean(false);
+  private final AtomicBoolean locatorsInitialized = new AtomicBoolean(false);
   private final Runnable locatorInitializationSequence;
-  private volatile Client locator;
+  private final List<Locator> locators = new CopyOnWriteArrayList<>();
 
   StreamEnvironment(
       ScheduledExecutorService scheduledExecutorService,
@@ -188,6 +189,8 @@ class StreamEnvironment implements Environment {
               .collect(Collectors.toList());
     }
 
+    this.addresses.forEach(address -> this.locators.add(new Locator(address)));
+
     if (clientParametersPrototype.eventLoopGroup == null) {
       this.eventLoopGroup = new NioEventLoopGroup();
       this.clientParametersPrototype =
@@ -199,14 +202,16 @@ class StreamEnvironment implements Environment {
               .duplicate()
               .eventLoopGroup(clientParametersPrototype.eventLoopGroup);
     }
+    ScheduledExecutorService executorService;
     if (scheduledExecutorService == null) {
-      this.scheduledExecutorService =
+      executorService =
           Executors.newScheduledThreadPool(Runtime.getRuntime().availableProcessors());
       this.privateScheduleExecutorService = true;
     } else {
-      this.scheduledExecutorService = scheduledExecutorService;
+      executorService = scheduledExecutorService;
       this.privateScheduleExecutorService = false;
     }
+    this.scheduledExecutorService = new ScheduledExecutorServiceWrapper(executorService);
 
     this.producersCoordinator =
         new ProducersCoordinator(
@@ -222,50 +227,13 @@ class StreamEnvironment implements Environment {
             connectionNamingStrategy,
             Utils.coordinatorClientFactory(this));
     this.offsetTrackingCoordinator = new OffsetTrackingCoordinator(this);
-
-    AtomicReference<Client.ShutdownListener> shutdownListenerReference = new AtomicReference<>();
-    Client.ShutdownListener shutdownListener =
-        shutdownContext -> {
-          if (shutdownContext.isShutdownUnexpected()) {
-            this.locator = null;
-            LOGGER.debug("Unexpected locator disconnection, trying to reconnect");
-            Client.ClientParameters newLocatorParameters =
-                this.clientParametersPrototype
-                    .duplicate()
-                    .shutdownListener(shutdownListenerReference.get());
-            AsyncRetry.asyncRetry(
-                    () -> {
-                      Address address =
-                          addresses.size() == 1
-                              ? addresses.get(0)
-                              : addresses.get(random.nextInt(addresses.size()));
-                      address = addressResolver.resolve(address);
-                      LOGGER.debug("Trying to reconnect locator on {}", address);
-                      String connectionName =
-                          connectionNamingStrategy.apply(ClientConnectionType.LOCATOR);
-                      Client newLocator =
-                          clientFactory.apply(
-                              newLocatorParameters
-                                  .host(address.host())
-                                  .port(address.port())
-                                  .clientProperty("connection_name", connectionName));
-                      LOGGER.debug("Created locator connection '{}'", connectionName);
-                      LOGGER.debug("Locator connected on {}", address);
-                      return newLocator;
-                    })
-                .description("Locator recovery")
-                .scheduler(this.scheduledExecutorService)
-                .delayPolicy(recoveryBackOffDelayPolicy)
-                .build()
-                .thenAccept(newLocator -> this.locator = newLocator);
-          }
-        };
-    shutdownListenerReference.set(shutdownListener);
     ClientParameters clientParametersForInit = clientParametersPrototype.duplicate();
     Runnable locatorInitSequence =
         () -> {
           RuntimeException lastException = null;
-          for (Address address : addresses) {
+          for (int i = 0; i < addresses.size(); i++) {
+            Address address = addresses.get(i);
+            Locator locator = locator(i);
             address = addressResolver.resolve(address);
             String connectionName = connectionNamingStrategy.apply(ClientConnectionType.LOCATOR);
             Client.ClientParameters locatorParameters =
@@ -274,26 +242,34 @@ class StreamEnvironment implements Environment {
                     .host(address.host())
                     .port(address.port())
                     .clientProperty("connection_name", connectionName)
-                    .shutdownListener(shutdownListenerReference.get());
+                    .shutdownListener(
+                        shutdownListener(locator, connectionNamingStrategy, clientFactory));
             try {
-              this.locator = clientFactory.apply(locatorParameters);
+              Client client = clientFactory.apply(locatorParameters);
+              locator.client(client);
               LOGGER.debug("Created locator connection '{}'", connectionName);
               LOGGER.debug("Locator connected to {}", address);
-              break;
             } catch (RuntimeException e) {
               LOGGER.debug("Error while try to connect to {}: {}", address, e.getMessage());
               lastException = e;
             }
           }
-          if (this.locator == null) {
+          if (this.locators.stream().allMatch(l -> l.isNotSet())) {
             throw lastException;
+          } else {
+            this.locators.forEach(
+                l -> {
+                  if (l.isNotSet()) {
+                    scheduleLocatorConnection(l, connectionNamingStrategy, clientFactory);
+                  }
+                });
           }
         };
     if (lazyInit) {
       this.locatorInitializationSequence = locatorInitSequence;
     } else {
       locatorInitSequence.run();
-      locatorInitialized.set(true);
+      locatorsInitialized.set(true);
       this.locatorInitializationSequence = () -> {};
     }
     this.codec =
@@ -302,7 +278,112 @@ class StreamEnvironment implements Environment {
             : clientParametersPrototype.codec();
     this.clockRefreshFuture =
         this.scheduledExecutorService.scheduleAtFixedRate(
-            () -> this.clock.refresh(), 1, 1, SECONDS);
+            Utils.namedRunnable(() -> this.clock.refresh(), "Background clock refresh"),
+            1,
+            1,
+            SECONDS);
+  }
+
+  private ShutdownListener shutdownListener(
+      Locator locator,
+      Function<ClientConnectionType, String> connectionNamingStrategy,
+      Function<Client.ClientParameters, Client> clientFactory) {
+    AtomicReference<Client.ShutdownListener> shutdownListenerReference = new AtomicReference<>();
+    Client.ShutdownListener shutdownListener =
+        shutdownContext -> {
+          if (shutdownContext.isShutdownUnexpected()) {
+            locator.client(null);
+            LOGGER.debug("Unexpected locator disconnection, trying to reconnect");
+            try {
+              Client.ClientParameters newLocatorParameters =
+                  this.clientParametersPrototype
+                      .duplicate()
+                      .shutdownListener(shutdownListenerReference.get());
+              AsyncRetry.asyncRetry(
+                      () -> {
+                        LOGGER.debug("Locator reconnection...");
+                        Address resolvedAddress = addressResolver.resolve(locator.address());
+                        String connectionName =
+                            connectionNamingStrategy.apply(ClientConnectionType.LOCATOR);
+                        LOGGER.debug(
+                            "Trying to reconnect locator on {}, with client connection name '{}'",
+                            resolvedAddress,
+                            connectionName);
+                        Client newLocator =
+                            clientFactory.apply(
+                                newLocatorParameters
+                                    .host(resolvedAddress.host())
+                                    .port(resolvedAddress.port())
+                                    .clientProperty("connection_name", connectionName));
+                        LOGGER.debug("Created locator connection '{}'", connectionName);
+                        LOGGER.debug("Locator connected on {}", resolvedAddress);
+                        return newLocator;
+                      })
+                  .description("Locator recovery")
+                  .scheduler(this.scheduledExecutorService)
+                  .delayPolicy(recoveryBackOffDelayPolicy)
+                  .build()
+                  .thenAccept(newClient -> locator.client(newClient))
+                  .exceptionally(
+                      ex -> {
+                        LOGGER.debug("Locator recovery failed", ex);
+                        return null;
+                      });
+            } catch (Exception e) {
+              LOGGER.debug("Error while scheduling locator reconnection", e);
+            }
+          }
+        };
+    shutdownListenerReference.set(shutdownListener);
+    return shutdownListener;
+  }
+
+  private void scheduleLocatorConnection(
+      Locator locator,
+      Function<ClientConnectionType, String> connectionNamingStrategy,
+      Function<Client.ClientParameters, Client> clientFactory) {
+    ShutdownListener shutdownListener =
+        shutdownListener(locator, connectionNamingStrategy, clientFactory);
+    try {
+      Client.ClientParameters newLocatorParameters =
+          this.clientParametersPrototype.duplicate().shutdownListener(shutdownListener);
+      AsyncRetry.asyncRetry(
+              () -> {
+                LOGGER.debug("Locator reconnection...");
+                Address resolvedAddress = addressResolver.resolve(locator.address());
+                String connectionName =
+                    connectionNamingStrategy.apply(ClientConnectionType.LOCATOR);
+                LOGGER.debug(
+                    "Trying to reconnect locator on {}, with client connection name '{}'",
+                    resolvedAddress,
+                    connectionName);
+                Client newLocator =
+                    clientFactory.apply(
+                        newLocatorParameters
+                            .host(resolvedAddress.host())
+                            .port(resolvedAddress.port())
+                            .clientProperty("connection_name", connectionName));
+                LOGGER.debug("Created locator connection '{}'", connectionName);
+                LOGGER.debug("Locator connected on {}", resolvedAddress);
+                return newLocator;
+              })
+          .description("Locator recovery")
+          .scheduler(this.scheduledExecutorService)
+          .delayPolicy(recoveryBackOffDelayPolicy)
+          .build()
+          .thenAccept(newClient -> locator.client(newClient))
+          .exceptionally(
+              ex -> {
+                LOGGER.debug("Locator recovery failed", ex);
+                return null;
+              });
+    } catch (Exception e) {
+      LOGGER.debug("Error while scheduling locator reconnection", e);
+    }
+  }
+
+  private Locator locator(int i) {
+    return this.locators.get(i);
   }
 
   private static String uriDecode(String s) {
@@ -361,11 +442,11 @@ class StreamEnvironment implements Environment {
   }
 
   void maybeInitializeLocator() {
-    if (this.locatorInitialized.compareAndSet(false, true)) {
+    if (this.locatorsInitialized.compareAndSet(false, true)) {
       try {
         this.locatorInitializationSequence.run();
       } catch (RuntimeException e) {
-        this.locatorInitialized.set(false);
+        this.locatorsInitialized.set(false);
         throw e;
       }
     }
@@ -398,14 +479,17 @@ class StreamEnvironment implements Environment {
     checkNotClosed();
     StreamStatsResponse response =
         locatorOperation(
-            client -> {
-              if (Utils.is3_11_OrMore(client.brokerVersion())) {
-                return client.streamStats(stream);
-              } else {
-                throw new UnsupportedOperationException(
-                    "QueryStringInfo is available only for RabbitMQ 3.11 or more.");
-              }
-            });
+            Utils.namedFunction(
+                client -> {
+                  if (Utils.is3_11_OrMore(client.brokerVersion())) {
+                    return client.streamStats(stream);
+                  } else {
+                    throw new UnsupportedOperationException(
+                        "QueryStringInfo is available only for RabbitMQ 3.11 or more.");
+                  }
+                },
+                "Query stream stats on stream '%s'",
+                stream));
     if (response.isOk()) {
       Map<String, Long> info = response.getInfo();
       BiFunction<String, String, LongSupplier> offsetSupplierLogic =
@@ -508,14 +592,17 @@ class StreamEnvironment implements Environment {
       this.consumersCoordinator.close();
       this.offsetTrackingCoordinator.close();
 
-      try {
-        if (this.locator != null && this.locator.isOpen()) {
-          this.locator.close();
-          this.locator = null;
+      for (Locator locator : this.locators) {
+        try {
+          if (locator.isSet()) {
+            locator.client().close();
+            locator.client(null);
+          }
+        } catch (Exception e) {
+          LOGGER.warn("Error while closing locator client", e);
         }
-      } catch (Exception e) {
-        LOGGER.warn("Error while closing locator client", e);
       }
+
       this.clockRefreshFuture.cancel(false);
       if (privateScheduleExecutorService) {
         this.scheduledExecutorService.shutdownNow();
@@ -539,6 +626,10 @@ class StreamEnvironment implements Environment {
 
   ScheduledExecutorService scheduledExecutorService() {
     return this.scheduledExecutorService;
+  }
+
+  void execute(Runnable task, String description, Object... args) {
+    this.scheduledExecutorService().execute(namedRunnable(task, description, args));
   }
 
   BackOffDelayPolicy recoveryBackOffDelayPolicy() {
@@ -580,10 +671,11 @@ class StreamEnvironment implements Environment {
   }
 
   Client locator() {
-    if (this.locator == null) {
-      throw new LocatorNotAvailableException();
-    }
-    return this.locator;
+    return this.locators.stream()
+        .filter(Locator::isSet)
+        .findAny()
+        .orElseThrow(() -> new LocatorNotAvailableException())
+        .client();
   }
 
   <T> T locatorOperation(Function<Client, T> operation) {
@@ -599,9 +691,15 @@ class StreamEnvironment implements Environment {
     boolean executed = false;
     Exception lastException = null;
     T result = null;
+    LOGGER.debug("Starting locator operation '{}'", operation);
+    long start = System.nanoTime();
     while (attempt < maxAttempt) {
       try {
         result = operation.apply(clientSupplier.get());
+        LOGGER.debug(
+            "Locator operation '{}' succeeded in {}",
+            operation,
+            Duration.ofNanos(System.nanoTime() - start));
         executed = true;
         break;
       } catch (LocatorNotAvailableException e) {
@@ -613,6 +711,10 @@ class StreamEnvironment implements Environment {
           Thread.currentThread().interrupt();
           break;
         }
+      } catch (Exception e) {
+        LOGGER.debug("Exception during locator operation '{}': {}", operation, e.getMessage());
+        lastException = e;
+        break;
       }
     }
     if (!executed) {
@@ -687,10 +789,15 @@ class StreamEnvironment implements Environment {
 
   @Override
   public String toString() {
-    Client locator = this.locator;
-    return "{ \"locator\" : "
-        + (locator == null ? "null" : ("\"" + locator.connectionName() + "\""))
-        + ", "
+    return "{ \"locators\" : ["
+        + this.locators.stream()
+            .map(
+                l -> {
+                  Client c = l.nullableClient();
+                  return c == null ? "null" : ("\"" + c.connectionName() + "\"");
+                })
+            .collect(Collectors.joining(","))
+        + "], "
         + "\"producers\" : "
         + this.producersCoordinator
         + ", \"consumers\" : "
@@ -745,6 +852,42 @@ class StreamEnvironment implements Environment {
   private void checkNotClosed() {
     if (this.closed.get()) {
       throw new IllegalStateException("This environment instance has been closed");
+    }
+  }
+
+  private static class Locator {
+
+    private final Address address;
+    private volatile Optional<Client> client;
+
+    private Locator(Address address) {
+      this.address = address;
+      this.client = Optional.empty();
+    }
+
+    Locator client(Client client) {
+      this.client = Optional.ofNullable(client);
+      return this;
+    }
+
+    private boolean isNotSet() {
+      return !this.isSet();
+    }
+
+    private boolean isSet() {
+      return this.client.isPresent();
+    }
+
+    private Client client() {
+      return this.client.orElseThrow(() -> new LocatorNotAvailableException());
+    }
+
+    private Client nullableClient() {
+      return this.client.orElse(null);
+    }
+
+    private Address address() {
+      return this.address;
     }
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
@@ -484,9 +484,10 @@ class StreamProducer implements Producer {
         }
       }
       publishBatch(false);
-      if (unconfirmedMessagesSemaphore.availablePermits() != maxUnconfirmedMessages) {
-        unconfirmedMessagesSemaphore.release(
-            maxUnconfirmedMessages - unconfirmedMessagesSemaphore.availablePermits());
+
+      int toRelease = maxUnconfirmedMessages - unconfirmedMessagesSemaphore.availablePermits();
+      if (toRelease > 0) {
+        unconfirmedMessagesSemaphore.release(toRelease);
         if (!unconfirmedMessagesSemaphore.tryAcquire(this.unconfirmedMessages.size())) {
           LOGGER.debug(
               "Could not acquire {} permit(s) for message republishing",

--- a/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
@@ -17,6 +17,7 @@ import static com.rabbitmq.stream.Constants.CODE_MESSAGE_ENQUEUEING_FAILED;
 import static com.rabbitmq.stream.Constants.CODE_PRODUCER_CLOSED;
 import static com.rabbitmq.stream.Constants.CODE_PRODUCER_NOT_AVAILABLE;
 import static com.rabbitmq.stream.impl.Utils.formatConstant;
+import static com.rabbitmq.stream.impl.Utils.namedRunnable;
 
 import com.rabbitmq.stream.Codec;
 import com.rabbitmq.stream.ConfirmationHandler;
@@ -166,13 +167,26 @@ class StreamProducer implements Producer {
               environment
                   .scheduledExecutorService()
                   .schedule(
-                      taskReference.get(), batchPublishingDelay.toMillis(), TimeUnit.MILLISECONDS);
+                      namedRunnable(
+                          taskReference.get(),
+                          "Background batch publishing task for publisher %d on stream '%s'",
+                          this.id,
+                          this.stream),
+                      batchPublishingDelay.toMillis(),
+                      TimeUnit.MILLISECONDS);
             }
           };
       taskReference.set(task);
       environment
           .scheduledExecutorService()
-          .schedule(task, batchPublishingDelay.toMillis(), TimeUnit.MILLISECONDS);
+          .schedule(
+              namedRunnable(
+                  task,
+                  "Background batch publishing task for publisher %d on stream '%s'",
+                  this.id,
+                  this.stream),
+              batchPublishingDelay.toMillis(),
+              TimeUnit.MILLISECONDS);
     }
     this.batchSize = batchSize;
     this.codec = environment.codec();
@@ -192,14 +206,27 @@ class StreamProducer implements Producer {
                   this.environment
                       .scheduledExecutorService()
                       .schedule(
-                          taskReference.get(), confirmTimeout.toMillis(), TimeUnit.MILLISECONDS);
+                          namedRunnable(
+                              taskReference.get(),
+                              "Background confirm timeout task for producer %d on stream %s",
+                              this.id,
+                              this.stream),
+                          confirmTimeout.toMillis(),
+                          TimeUnit.MILLISECONDS);
             }
           };
       taskReference.set(wrapperTask);
       this.confirmTimeoutFuture =
           this.environment
               .scheduledExecutorService()
-              .schedule(taskReference.get(), confirmTimeout.toMillis(), TimeUnit.MILLISECONDS);
+              .schedule(
+                  namedRunnable(
+                      taskReference.get(),
+                      "Background confirm timeout task for producer %d on stream %s",
+                      this.id,
+                      this.stream),
+                  confirmTimeout.toMillis(),
+                  TimeUnit.MILLISECONDS);
     }
     this.status = Status.RUNNING;
   }
@@ -209,7 +236,6 @@ class StreamProducer implements Producer {
       long limit = this.environment.clock().time() - confirmTimeout.toNanos();
       SortedMap<Long, AccumulatedEntity> unconfirmedSnapshot =
           new TreeMap<>(this.unconfirmedMessages);
-      LOGGER.debug("Starting confirm timeout check task");
       int count = 0;
       for (Entry<Long, AccumulatedEntity> unconfirmedEntry : unconfirmedSnapshot.entrySet()) {
         if (unconfirmedEntry.getValue().time() < limit) {
@@ -223,7 +249,15 @@ class StreamProducer implements Producer {
           break;
         }
       }
-      LOGGER.debug("Failed {} message(s) which had timed out (limit {})", count, limit);
+      if (count > 0) {
+        LOGGER.debug(
+            "{} outbound message(s) had reached the confirm timeout (limit {}) "
+                + "for producer {} on stream '{}', application notified with callback",
+            count,
+            limit,
+            this.id,
+            this.stream);
+      }
     };
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/StreamStreamCreator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamStreamCreator.java
@@ -14,6 +14,7 @@
 package com.rabbitmq.stream.impl;
 
 import static com.rabbitmq.stream.impl.Utils.formatConstant;
+import static com.rabbitmq.stream.impl.Utils.namedFunction;
 
 import com.rabbitmq.stream.ByteCapacity;
 import com.rabbitmq.stream.Constants;
@@ -73,7 +74,11 @@ class StreamStreamCreator implements StreamCreator {
     }
     this.environment.maybeInitializeLocator();
     Client.Response response =
-        environment.locatorOperation(c -> c.create(stream, streamParametersBuilder.build()));
+        environment.locatorOperation(
+            namedFunction(
+                c -> c.create(stream, streamParametersBuilder.build()),
+                "Creation of stream '%s'",
+                this.stream));
     if (!response.isOk()
         && response.getResponseCode() != Constants.RESPONSE_CODE_STREAM_ALREADY_EXISTS) {
       throw new StreamException(

--- a/src/main/java/com/rabbitmq/stream/impl/SuperStreamConsumer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/SuperStreamConsumer.java
@@ -13,6 +13,8 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
+import static com.rabbitmq.stream.impl.Utils.namedFunction;
+
 import com.rabbitmq.stream.Consumer;
 import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageHandler;
@@ -38,7 +40,12 @@ class SuperStreamConsumer implements Consumer {
       StreamEnvironment environment,
       TrackingConfiguration trackingConfiguration) {
     this.superStream = superStream;
-    List<String> partitions = environment.locatorOperation(c -> c.partitions(superStream));
+    List<String> partitions =
+        environment.locatorOperation(
+            namedFunction(
+                c -> c.partitions(superStream),
+                "Partition lookup for super stream '%s'",
+                superStream));
 
     // for manual offset tracking strategy only
     ConsumerState[] states = new ConsumerState[partitions.size()];

--- a/src/main/java/com/rabbitmq/stream/impl/TimeoutStreamException.java
+++ b/src/main/java/com/rabbitmq/stream/impl/TimeoutStreamException.java
@@ -1,0 +1,23 @@
+// Copyright (c) 2022 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import com.rabbitmq.stream.StreamException;
+
+class TimeoutStreamException extends StreamException {
+
+  public TimeoutStreamException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/impl/TimeoutStreamException.java
+++ b/src/main/java/com/rabbitmq/stream/impl/TimeoutStreamException.java
@@ -20,4 +20,8 @@ class TimeoutStreamException extends StreamException {
   public TimeoutStreamException(String message) {
     super(message);
   }
+
+  public TimeoutStreamException(String message, Throwable cause) {
+    super(message, cause);
+  }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Utils.java
@@ -38,6 +38,7 @@ import java.util.function.Function;
 import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import javax.net.ssl.X509TrustManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -339,14 +340,14 @@ final class Utils {
     return versionCompare(currentVersion(brokerVersion), "3.11.0") >= 0;
   }
 
-  static StreamException propagateException(short responseCode, String stream) {
+  static StreamException convertCodeToException(
+      short responseCode, String stream, Supplier<String> fallbackMessage) {
     if (responseCode == Constants.RESPONSE_CODE_STREAM_DOES_NOT_EXIST) {
       return new StreamDoesNotExistException(stream);
     } else if (responseCode == Constants.RESPONSE_CODE_STREAM_NOT_AVAILABLE) {
       return new StreamNotAvailableException(stream);
     } else {
-      String message = "Error while querying stream info: " + formatConstant(responseCode) + ".";
-      return new StreamException(message, responseCode);
+      return new StreamException(fallbackMessage.get(), responseCode);
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Utils.java
@@ -200,7 +200,9 @@ final class Utils {
       }
     }
     String message =
-        format("Could not complete task '%s' after %d attempt(s)", description, --attempt);
+        format(
+            "Could not complete task '%s' after %d attempt(s) (reason: {})",
+            description, --attempt, exceptionMessage(lastException));
     LOGGER.debug(message);
     if (lastException == null) {
       throw new StreamException(message);
@@ -208,6 +210,16 @@ final class Utils {
       throw (RuntimeException) lastException;
     } else {
       throw new StreamException(message, lastException);
+    }
+  }
+
+  static String exceptionMessage(Exception e) {
+    if (e == null) {
+      return "unknown";
+    } else if (e.getMessage() == null) {
+      return e.getClass().getSimpleName();
+    } else {
+      return e.getMessage() + " [" + e.getClass().getSimpleName() + "]";
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Utils.java
@@ -151,6 +151,14 @@ final class Utils {
         retryInterval);
   }
 
+  static Runnable namedRunnable(Runnable task, String format, Object... args) {
+    return new NamedRunnable(String.format(format, args), task);
+  }
+
+  static <T, R> Function<T, R> namedFunction(Function<T, R> task, String format, Object... args) {
+    return new NamedFunction<>(String.format(format, args), task);
+  }
+
   interface ClientFactory {
 
     Client client(ClientFactoryContext context);
@@ -339,6 +347,48 @@ final class Utils {
     } else {
       String message = "Error while querying stream info: " + formatConstant(responseCode) + ".";
       return new StreamException(message, responseCode);
+    }
+  }
+
+  private static class NamedRunnable implements Runnable {
+
+    private final String name;
+    private final Runnable delegate;
+
+    private NamedRunnable(String name, Runnable delegate) {
+      this.name = name;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public void run() {
+      this.delegate.run();
+    }
+
+    @Override
+    public String toString() {
+      return this.name;
+    }
+  }
+
+  private static class NamedFunction<T, R> implements Function<T, R> {
+
+    private final String name;
+    private final Function<T, R> delegate;
+
+    private NamedFunction(String name, Function<T, R> delegate) {
+      this.name = name;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public R apply(T t) {
+      return this.delegate.apply(t);
+    }
+
+    @Override
+    public String toString() {
+      return this.name;
     }
   }
 }

--- a/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
+++ b/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
@@ -63,19 +63,19 @@ class MonitoringTestUtils {
 
   public static class EnvironmentInfo {
 
-    private final String locator;
+    private final String[] locators;
     private final ProducersPoolInfo[] producers;
     private final ConsumersPoolInfo[] consumers;
 
     public EnvironmentInfo(
-        String locator, ProducersPoolInfo[] producers, ConsumersPoolInfo[] consumers) {
-      this.locator = locator;
+        String[] locators, ProducersPoolInfo[] producers, ConsumersPoolInfo[] consumers) {
+      this.locators = locators;
       this.producers = producers;
       this.consumers = consumers;
     }
 
-    public String getLocator() {
-      return locator;
+    public String[] getLocators() {
+      return locators;
     }
 
     public List<ConsumersPoolInfo> getConsumers() {
@@ -89,8 +89,8 @@ class MonitoringTestUtils {
     @Override
     public String toString() {
       return "EnvironmentInfo{"
-          + "locator='"
-          + locator
+          + "locators='"
+          + Arrays.toString(locators)
           + '\''
           + ", producers="
           + Arrays.toString(producers)

--- a/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
+++ b/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
@@ -40,9 +40,8 @@ class MonitoringTestUtils {
     return GSON.fromJson(coordinator.toString(), type);
   }
 
-  static List<ConsumersPoolInfo> extract(ConsumersCoordinator coordinator) {
-    Type type = new TypeToken<List<ConsumersPoolInfo>>() {}.getType();
-    return GSON.fromJson(coordinator.toString(), type);
+  static ConsumerCoordinatorInfo extract(ConsumersCoordinator coordinator) {
+    return GSON.fromJson(coordinator.toString(), ConsumerCoordinatorInfo.class);
   }
 
   static EnvironmentInfo extract(Environment environment) {
@@ -65,10 +64,10 @@ class MonitoringTestUtils {
 
     private final String[] locators;
     private final ProducersPoolInfo[] producers;
-    private final ConsumersPoolInfo[] consumers;
+    private final ConsumerCoordinatorInfo consumers;
 
     public EnvironmentInfo(
-        String[] locators, ProducersPoolInfo[] producers, ConsumersPoolInfo[] consumers) {
+        String[] locators, ProducersPoolInfo[] producers, ConsumerCoordinatorInfo consumers) {
       this.locators = locators;
       this.producers = producers;
       this.consumers = consumers;
@@ -79,7 +78,7 @@ class MonitoringTestUtils {
     }
 
     public List<ConsumersPoolInfo> getConsumers() {
-      return arrayToList(this.consumers);
+      return this.consumers.consumerCoordinatorInfos();
     }
 
     public List<ProducersPoolInfo> getProducers() {
@@ -95,8 +94,30 @@ class MonitoringTestUtils {
           + ", producers="
           + Arrays.toString(producers)
           + ", consumers="
-          + Arrays.toString(consumers)
+          + consumers
           + '}';
+    }
+  }
+
+  public static class ConsumerCoordinatorInfo {
+
+    private final int subscription_count;
+    private final int pool_count;
+    private final ConsumersPoolInfo[] pools;
+
+    public ConsumerCoordinatorInfo(
+        int subscription_count, int pool_count, ConsumersPoolInfo[] pools) {
+      this.subscription_count = subscription_count;
+      this.pool_count = pool_count;
+      this.pools = pools;
+    }
+
+    boolean isEmpty() {
+      return this.pool_count == 0;
+    }
+
+    List<ConsumersPoolInfo> consumerCoordinatorInfos() {
+      return Arrays.asList(this.pools);
     }
   }
 

--- a/src/test/java/com/rabbitmq/stream/impl/OffsetTrackingCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/OffsetTrackingCoordinatorTest.java
@@ -50,7 +50,7 @@ public class OffsetTrackingCoordinatorTest {
   @BeforeEach
   void init() {
     mocks = MockitoAnnotations.openMocks(this);
-    executorService = Executors.newScheduledThreadPool(2);
+    executorService = new ScheduledExecutorServiceWrapper(Executors.newScheduledThreadPool(2));
     when(env.scheduledExecutorService()).thenReturn(executorService);
     when(consumer.isOpen()).thenReturn(true);
   }

--- a/src/test/java/com/rabbitmq/stream/impl/ProducersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ProducersCoordinatorTest.java
@@ -229,7 +229,7 @@ public class ProducersCoordinatorTest {
 
   @Test
   void shouldRedistributeProducerAndTrackingConsumerIfConnectionIsLost() throws Exception {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    scheduledExecutorService = createScheduledExecutorService();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
     Duration retryDelay = Duration.ofMillis(50);
     when(environment.recoveryBackOffDelayPolicy()).thenReturn(BackOffDelayPolicy.fixed(retryDelay));
@@ -295,7 +295,7 @@ public class ProducersCoordinatorTest {
 
   @Test
   void shouldDisposeProducerAndNotTrackingConsumerIfRecoveryTimesOut() throws Exception {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    scheduledExecutorService = createScheduledExecutorService();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
     when(environment.recoveryBackOffDelayPolicy())
         .thenReturn(BackOffDelayPolicy.fixedWithInitialDelay(ms(10), ms(10), ms(100)));
@@ -336,7 +336,7 @@ public class ProducersCoordinatorTest {
 
   @Test
   void shouldRedistributeProducersAndTrackingConsumersOnMetadataUpdate() throws Exception {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    scheduledExecutorService = createScheduledExecutorService();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
     Duration retryDelay = Duration.ofMillis(50);
     when(environment.topologyUpdateBackOffDelayPolicy())
@@ -426,7 +426,7 @@ public class ProducersCoordinatorTest {
 
   @Test
   void shouldDisposeProducerIfStreamIsDeleted() throws Exception {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    scheduledExecutorService = createScheduledExecutorService();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
     when(environment.topologyUpdateBackOffDelayPolicy())
         .thenReturn(BackOffDelayPolicy.fixedWithInitialDelay(ms(10), ms(10), ms(100)));
@@ -460,7 +460,7 @@ public class ProducersCoordinatorTest {
 
   @Test
   void shouldDisposeProducerAndNotTrackingConsumerIfMetadataUpdateTimesOut() throws Exception {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    scheduledExecutorService = createScheduledExecutorService();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
     when(environment.topologyUpdateBackOffDelayPolicy())
         .thenReturn(BackOffDelayPolicy.fixedWithInitialDelay(ms(10), ms(10), ms(100)));
@@ -500,7 +500,7 @@ public class ProducersCoordinatorTest {
 
   @Test
   void growShrinkResourcesBasedOnProducersAndTrackingConsumersCount() {
-    scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    scheduledExecutorService = createScheduledExecutorService();
     when(environment.scheduledExecutorService()).thenReturn(scheduledExecutorService);
     when(locator.metadata("stream")).thenReturn(metadata(leader(), replicas()));
 
@@ -600,5 +600,9 @@ public class ProducersCoordinatorTest {
 
     assertThat(coordinator.poolSize()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
+  }
+
+  private static ScheduledExecutorService createScheduledExecutorService() {
+    return new ScheduledExecutorServiceWrapper(Executors.newSingleThreadScheduledExecutor());
   }
 }

--- a/src/test/java/com/rabbitmq/stream/impl/ProducersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ProducersCoordinatorTest.java
@@ -118,6 +118,8 @@ public class ProducersCoordinatorTest {
             ProducersCoordinator.MAX_TRACKING_CONSUMERS_PER_CLIENT,
             type -> "producer-connection",
             clientFactory);
+    when(client.isOpen()).thenReturn(true);
+    when(client.deletePublisher(anyByte())).thenReturn(new Response(Constants.RESPONSE_CODE_OK));
   }
 
   @AfterEach
@@ -272,7 +274,7 @@ public class ProducersCoordinatorTest {
     verify(producer, times(1)).setClient(client);
     verify(trackingConsumer, times(1)).setTrackingClient(client);
     verify(producerClosedAfterDisconnection, times(1)).setClient(client);
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
 
     shutdownListener.handle(
@@ -289,7 +291,7 @@ public class ProducersCoordinatorTest {
     verify(producerClosedAfterDisconnection, times(1)).unavailable();
     verify(producerClosedAfterDisconnection, times(1)).setClient(client);
     verify(producerClosedAfterDisconnection, never()).running();
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
   }
 
@@ -316,7 +318,7 @@ public class ProducersCoordinatorTest {
 
     verify(producer, times(1)).setClient(client);
     verify(trackingConsumer, times(1)).setTrackingClient(client);
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
 
     shutdownListener.handle(
@@ -330,7 +332,7 @@ public class ProducersCoordinatorTest {
     verify(trackingConsumer, times(1)).setTrackingClient(client);
     verify(trackingConsumer, never()).running();
     verify(trackingConsumer, never()).closeAfterStreamDeletion();
-    assertThat(coordinator.poolSize()).isEqualTo(0);
+    assertThat(coordinator.nodesConnected()).isEqualTo(0);
     assertThat(coordinator.clientCount()).isEqualTo(0);
   }
 
@@ -396,7 +398,6 @@ public class ProducersCoordinatorTest {
     verify(producerClosedAfterDisconnection, times(1)).setClient(client);
     verify(movingTrackingConsumer, times(1)).setTrackingClient(client);
     verify(fixedTrackingConsumer, times(1)).setTrackingClient(client);
-    assertThat(coordinator.poolSize()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
 
     metadataListener.handle(movingStream, Constants.RESPONSE_CODE_STREAM_NOT_AVAILABLE);
@@ -420,7 +421,7 @@ public class ProducersCoordinatorTest {
     verify(fixedTrackingConsumer, never()).unavailable();
     verify(fixedTrackingConsumer, times(1)).setTrackingClient(client);
     verify(fixedTrackingConsumer, never()).running();
-    assertThat(coordinator.poolSize()).isEqualTo(2);
+    assertThat(coordinator.nodesConnected()).isEqualTo(2);
     assertThat(coordinator.clientCount()).isEqualTo(2);
   }
 
@@ -444,7 +445,6 @@ public class ProducersCoordinatorTest {
     coordinator.registerProducer(producer, null, "stream");
 
     verify(producer, times(1)).setClient(client);
-    assertThat(coordinator.poolSize()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
 
     metadataListener.handle("stream", Constants.RESPONSE_CODE_STREAM_NOT_AVAILABLE);
@@ -454,7 +454,6 @@ public class ProducersCoordinatorTest {
     verify(producer, times(1)).setClient(client);
     verify(producer, never()).running();
 
-    assertThat(coordinator.poolSize()).isEqualTo(0);
     assertThat(coordinator.clientCount()).isEqualTo(0);
   }
 
@@ -481,7 +480,7 @@ public class ProducersCoordinatorTest {
 
     verify(producer, times(1)).setClient(client);
     verify(trackingConsumer, times(1)).setTrackingClient(client);
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
 
     metadataListener.handle("stream", Constants.RESPONSE_CODE_STREAM_NOT_AVAILABLE);
@@ -494,7 +493,7 @@ public class ProducersCoordinatorTest {
     verify(trackingConsumer, times(1)).setTrackingClient(client);
     verify(trackingConsumer, never()).running();
     verify(trackingConsumer, never()).closeAfterStreamDeletion();
-    assertThat(coordinator.poolSize()).isEqualTo(0);
+    assertThat(coordinator.nodesConnected()).isEqualTo(0);
     assertThat(coordinator.clientCount()).isEqualTo(0);
   }
 
@@ -529,7 +528,7 @@ public class ProducersCoordinatorTest {
               producerInfos.add(info);
             });
 
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(2);
 
     // let's add some tracking consumers
@@ -554,7 +553,7 @@ public class ProducersCoordinatorTest {
               trackingConsumerInfos.add(info);
             });
 
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount())
         .as("new tracking consumers needs yet another client")
         .isEqualTo(3);
@@ -588,7 +587,7 @@ public class ProducersCoordinatorTest {
     verify(p, times(1)).setClient(client);
     assertThat(publishingIdForNewProducer.get()).isEqualTo(info.publishingId);
 
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(2);
 
     // close some of the last producers, this should free a whole producer manager and a bit of the
@@ -598,7 +597,7 @@ public class ProducersCoordinatorTest {
       producerInfo.cleaningCallback.run();
     }
 
-    assertThat(coordinator.poolSize()).isEqualTo(1);
+    assertThat(coordinator.nodesConnected()).isEqualTo(1);
     assertThat(coordinator.clientCount()).isEqualTo(1);
   }
 

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentTest.java
@@ -20,6 +20,8 @@ import static com.rabbitmq.stream.impl.TestUtils.localhostTls;
 import static com.rabbitmq.stream.impl.TestUtils.streamName;
 import static com.rabbitmq.stream.impl.TestUtils.waitAtMost;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -34,6 +36,7 @@ import com.rabbitmq.stream.ConsumerBuilder;
 import com.rabbitmq.stream.Environment;
 import com.rabbitmq.stream.EnvironmentBuilder;
 import com.rabbitmq.stream.Host;
+import com.rabbitmq.stream.Host.ConnectionInfo;
 import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.NoOffsetException;
 import com.rabbitmq.stream.OffsetSpecification;
@@ -64,8 +67,8 @@ import java.util.UUID;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.net.ssl.SNIHostName;
 import javax.net.ssl.SSLParameters;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
@@ -180,24 +183,24 @@ public class StreamEnvironmentTest {
   void producersAndConsumersShouldBeClosedWhenEnvironmentIsClosed(boolean lazyInit) {
     Environment environment = environmentBuilder.lazyInitialization(lazyInit).build();
     Collection<Producer> producers =
-        IntStream.range(0, 2)
+        range(0, 2)
             .mapToObj(i -> environment.producerBuilder().stream(stream).build())
-            .collect(Collectors.toList());
+            .collect(toList());
     Collection<Consumer> consumers =
-        IntStream.range(0, 2)
+        range(0, 2)
             .mapToObj(
                 i ->
                     environment.consumerBuilder().stream(stream)
                         .name(UUID.randomUUID().toString())
                         .messageHandler((offset, message) -> {})
                         .build())
-            .collect(Collectors.toList());
+            .collect(toList());
 
     producers.forEach(producer -> assertThat(((StreamProducer) producer).isOpen()).isTrue());
     consumers.forEach(consumer -> assertThat(((StreamConsumer) consumer).isOpen()).isTrue());
 
     EnvironmentInfo environmentInfo = MonitoringTestUtils.extract(environment);
-    assertThat(environmentInfo.getLocator()).isNotNull();
+    assertThat(environmentInfo.getLocators()).isNotEmpty();
     assertThat(environmentInfo.getProducers())
         .hasSize(1)
         .element(0)
@@ -223,7 +226,7 @@ public class StreamEnvironmentTest {
     consumers.forEach(consumer -> assertThat(((StreamConsumer) consumer).isOpen()).isFalse());
 
     environmentInfo = MonitoringTestUtils.extract(environment);
-    assertThat(environmentInfo.getLocator()).isNull();
+    assertThat(environmentInfo.getLocators()).isNotEmpty();
     assertThat(environmentInfo.getProducers()).isEmpty();
     assertThat(environmentInfo.getConsumers()).isEmpty();
   }
@@ -237,7 +240,7 @@ public class StreamEnvironmentTest {
 
     try (Environment environment = environmentBuilder.rpcTimeout(Duration.ofSeconds(20)).build()) {
       List<String> streams =
-          IntStream.range(0, streamCount)
+          range(0, streamCount)
               .mapToObj(i -> streamName(info))
               .map(
                   s -> {
@@ -250,16 +253,16 @@ public class StreamEnvironmentTest {
       CountDownLatch consumeLatch = new CountDownLatch(messageCount * producersCount);
 
       List<Producer> producers =
-          IntStream.range(0, producersCount)
+          range(0, producersCount)
               .mapToObj(
                   i -> {
                     String s = streams.get(i % streams.size());
                     return environment.producerBuilder().stream(s).build();
                   })
-              .collect(Collectors.toList());
+              .collect(toList());
 
       List<Consumer> consumers =
-          IntStream.range(0, consumersCount)
+          range(0, consumersCount)
               .mapToObj(
                   i -> {
                     String s = streams.get(new Random().nextInt(streams.size()));
@@ -267,13 +270,13 @@ public class StreamEnvironmentTest {
                         .messageHandler((offset, message) -> consumeLatch.countDown())
                         .build();
                   })
-              .collect(Collectors.toList());
+              .collect(toList());
 
       producers.stream()
           .parallel()
           .forEach(
               producer -> {
-                IntStream.range(0, messageCount)
+                range(0, messageCount)
                     .forEach(
                         messageIndex -> {
                           producer.send(
@@ -404,6 +407,48 @@ public class StreamEnvironmentTest {
   }
 
   @Test
+  @TestUtils.DisabledIfRabbitMqCtlNotSet
+  void shouldHaveSeveralLocatorsWhenSeveralUrisSpecifiedAndShouldRecoverThemIfClosed(TestInfo info)
+      throws Exception {
+    List<String> uris =
+        range(0, 3).mapToObj(ignored -> "rabbitmq-stream://localhost:5552").collect(toList());
+    try (Environment environment =
+        environmentBuilder
+            .recoveryBackOffDelayPolicy(BackOffDelayPolicy.fixed(Duration.ofSeconds(1)))
+            .uris(uris)
+            .build()) {
+      String s = streamName(info);
+      environment.streamCreator().stream(s).create();
+      environment.deleteStream(s);
+
+      Supplier<List<String>> locatorConnectionNamesSupplier =
+          () ->
+              Host.listConnections().stream()
+                  .map(ConnectionInfo::clientProvidedName)
+                  .filter(name -> name.contains("-locator-"))
+                  .collect(toList());
+      List<String> locatorConnectionNames = locatorConnectionNamesSupplier.get();
+      assertThat(locatorConnectionNames).hasSameSizeAs(uris);
+
+      locatorConnectionNames.forEach(connectionName -> Host.killConnection(connectionName));
+
+      environment.streamCreator().stream(s).create();
+      try {
+        Producer producer = environment.producerBuilder().stream(s).build();
+        Consumer consumer =
+            environment.consumerBuilder().stream(s)
+                .messageHandler((context, message) -> {})
+                .build();
+        producer.close();
+        consumer.close();
+      } finally {
+        environment.deleteStream(s);
+      }
+      waitAtMost(() -> locatorConnectionNamesSupplier.get().size() == uris.size());
+    }
+  }
+
+  @Test
   void createDelete(TestInfo info) {
     try (Environment environment = environmentBuilder.build();
         Client client = new Client()) {
@@ -482,7 +527,7 @@ public class StreamEnvironmentTest {
 
       Producer producer = env.producerBuilder().stream(s).build();
       ConfirmationHandler confirmationHandler = confirmationStatus -> confirmLatch.countDown();
-      IntStream.range(0, messageCount)
+      range(0, messageCount)
           .forEach(
               i -> {
                 Message message =

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -191,7 +192,9 @@ public class StreamEnvironmentUnitTest {
     AtomicInteger counter = new AtomicInteger();
     int result =
         StreamEnvironment.locatorOperation(
-            c -> counter.incrementAndGet(), () -> null, BackOffDelayPolicy.fixed(Duration.ZERO));
+            c -> counter.incrementAndGet(),
+            CLIENT_SUPPLIER,
+            BackOffDelayPolicy.fixed(Duration.ZERO));
     assertThat(result).isEqualTo(1);
   }
 
@@ -207,7 +210,7 @@ public class StreamEnvironmentUnitTest {
                 return counter.get();
               }
             },
-            () -> null,
+            CLIENT_SUPPLIER,
             BackOffDelayPolicy.fixed(Duration.ofMillis(10)));
     assertThat(result).isEqualTo(2);
   }
@@ -222,7 +225,7 @@ public class StreamEnvironmentUnitTest {
                       counter.incrementAndGet();
                       throw new LocatorNotAvailableException();
                     },
-                    () -> null,
+                    CLIENT_SUPPLIER,
                     BackOffDelayPolicy.fixed(Duration.ofMillis(10))))
         .isInstanceOf(LocatorNotAvailableException.class);
     assertThat(counter).hasValue(3);
@@ -242,7 +245,7 @@ public class StreamEnvironmentUnitTest {
                       latch.countDown();
                       throw new LocatorNotAvailableException();
                     },
-                    () -> null,
+                    CLIENT_SUPPLIER,
                     BackOffDelayPolicy.fixed(Duration.ofMinutes(10)));
               } catch (StreamException e) {
                 exception.set(e);
@@ -268,9 +271,11 @@ public class StreamEnvironmentUnitTest {
                       counter.incrementAndGet();
                       throw new RuntimeException();
                     },
-                    () -> null,
+                    CLIENT_SUPPLIER,
                     BackOffDelayPolicy.fixed(Duration.ofMillis(10))))
         .isInstanceOf(RuntimeException.class);
     assertThat(counter).hasValue(1);
   }
+
+  private static final Supplier<Client> CLIENT_SUPPLIER = () -> mock(Client.class);
 }

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
@@ -133,6 +133,8 @@ public class StreamEnvironmentUnitTest {
   @SuppressWarnings("unchecked")
   void shouldTryUrisOnInitializationFailure() throws Exception {
     reset(cf);
+    // we don't want the scheduled retry to kick in
+    when(recoveryBackOffDelayPolicy.delay(anyInt())).thenReturn(Duration.ofMinutes(60));
     when(cf.apply(any(Client.ClientParameters.class)))
         .thenThrow(new RuntimeException())
         .thenThrow(new RuntimeException())

--- a/src/test/java/com/rabbitmq/stream/impl/StreamProducerTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamProducerTest.java
@@ -637,7 +637,7 @@ public class StreamProducerTest {
   }
 
   @Test
-  void methodsShouldThrowExceptionWhenProducerIsClosed() {
+  void methodsShouldThrowExceptionWhenProducerIsClosed() throws InterruptedException {
     Producer producer = environment.producerBuilder().stream(stream).build();
     producer.close();
     assertThatThrownBy(() -> producer.getLastPublishingId())

--- a/src/test/java/com/rabbitmq/stream/impl/StreamProducerUnitTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamProducerUnitTest.java
@@ -111,7 +111,6 @@ public class StreamProducerUnitTest {
             any(ToLongFunction.class)))
         .thenCallRealMethod();
     when(env.scheduledExecutorService()).thenReturn(executorService);
-    when(env.locator()).thenReturn(client);
     when(env.locatorOperation(any())).thenCallRealMethod();
     when(env.clock()).thenReturn(clock);
     when(env.codec()).thenReturn(new SimpleCodec());


### PR DESCRIPTION
Create a locator connection for each provided URI. This way a connection can take over when the locator node goes down. This speeds up recovery.

Track scheduled tasks. This is likely to be disabled in a stable release. Useful to track down unfinished tasks.

Add retry to operations in the consumer coordinator.

Refresh consumer candidate nodes if the re-assignment of a consumer times out.

This improvements are based on the feedback from the effects of a rolling restart in K8S using stream-perf-test. Not all producers and consumers are recovered after all nodes have been restarted. The changes in this commit mitigates this problem.