### PR TITLE
Exchange command versions in connection

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
@@ -729,7 +729,6 @@ class ConsumersCoordinator {
               .key(name);
       this.client = clientFactory.client(clientFactoryContext);
       LOGGER.debug("Created consumer connection '{}'", connectionName);
-      maybeExchangeCommandVersions(client);
       clientInitializedInManager.set(true);
     }
 
@@ -1146,16 +1145,6 @@ class ConsumersCoordinator {
     @Override
     public String toString() {
       return "SubscriptionContext{" + "offsetSpecification=" + offsetSpecification + '}';
-    }
-  }
-
-  private static void maybeExchangeCommandVersions(Client client) {
-    try {
-      if (Utils.is3_11_OrMore(client.brokerVersion())) {
-        client.exchangeCommandVersions();
-      }
-    } catch (Exception e) {
-      LOGGER.info("Error while exchanging command versions: {}", e.getMessage());
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
@@ -83,6 +83,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.slf4j.Logger;
@@ -183,6 +184,23 @@ class ServerFrameHandler {
           + ", maxVersion="
           + maxVersion
           + '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      FrameHandlerInfo that = (FrameHandlerInfo) o;
+      return key == that.key && minVersion == that.minVersion && maxVersion == that.maxVersion;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(key, minVersion, maxVersion);
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -481,16 +481,7 @@ class StreamEnvironment implements Environment {
     StreamStatsResponse response =
         locatorOperation(
             Utils.namedFunction(
-                client -> {
-                  if (Utils.is3_11_OrMore(client.brokerVersion())) {
-                    return client.streamStats(stream);
-                  } else {
-                    throw new UnsupportedOperationException(
-                        "QueryStringInfo is available only for RabbitMQ 3.11 or more.");
-                  }
-                },
-                "Query stream stats on stream '%s'",
-                stream));
+                client -> client.streamStats(stream), "Query stream stats on stream '%s'", stream));
     if (response.isOk()) {
       Map<String, Long> info = response.getInfo();
       BiFunction<String, String, LongSupplier> offsetSupplierLogic =


### PR DESCRIPTION
Command availability (only StreamStats for now) was based on broker version. This commit makes
the exchange for each open connection and
make sure the users of Client won't call a command not supported by the broker.