### PR TITLE
Dispatch messages in dedicated thread

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/DefaultExecutorServiceFactory.java
+++ b/src/main/java/com/rabbitmq/stream/impl/DefaultExecutorServiceFactory.java
@@ -1,0 +1,201 @@
+// Copyright (c) 2023 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import com.rabbitmq.stream.impl.Utils.NamedThreadFactory;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.IntStream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultExecutorServiceFactory.class);
+  private static final Comparator<Executor> EXECUTOR_COMPARATOR =
+      Comparator.comparingInt(Executor::usage);
+
+  private final List<Executor> executors;
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  private final ThreadFactory threadFactory;
+  private final int minSize;
+  private final int clientPerExecutor;
+  private final Supplier<Executor> executorFactory;
+
+  DefaultExecutorServiceFactory() {
+    this(Runtime.getRuntime().availableProcessors(), 10);
+  }
+
+  DefaultExecutorServiceFactory(int minSize, int clientPerExecutor) {
+    this.minSize = minSize;
+    this.clientPerExecutor = clientPerExecutor;
+    this.threadFactory = new NamedThreadFactory("rabbitmq-stream-connection-");
+    this.executorFactory = () -> newExecutor();
+    List<Executor> l = new ArrayList<>(Runtime.getRuntime().availableProcessors());
+    IntStream.range(0, Runtime.getRuntime().availableProcessors())
+        .forEach(ignored -> l.add(this.executorFactory.get()));
+    executors = new CopyOnWriteArrayList<>(l);
+  }
+
+  static void maybeResize(
+      List<Executor> current, int min, int clientsPerResource, Supplier<Executor> factory) {
+    LOGGER.debug(
+        "Resizing {}, with min = {}, clients per resource = {}", current, min, clientsPerResource);
+    int clientCount = 0;
+    for (Executor executor : current) {
+      clientCount += executor.usage();
+    }
+    LOGGER.debug("Total usage is {}", clientCount);
+
+    int target = Math.max((clientCount / clientsPerResource) + 1, min);
+    LOGGER.debug("Target size is {}, current size is {}", target, current.size());
+    if (target > current.size()) {
+      LOGGER.debug("Upsizing...");
+      List<Executor> l = new ArrayList<>();
+      for (int i = 0; i < target; i++) {
+        if (i < current.size()) {
+          l.add(current.get(i));
+        } else {
+          l.add(factory.get());
+        }
+      }
+      current.clear();
+      current.addAll(l);
+      LOGGER.debug("New list is {}", current);
+    } else if (target < current.size()) {
+      LOGGER.debug("Downsizing...");
+      boolean hasUnusedExecutors = current.stream().filter(ex -> ex.usage() == 0).count() > 0;
+      if (!hasUnusedExecutors) {
+        LOGGER.debug("No downsizing, there is no unused executor");
+      }
+      if (hasUnusedExecutors) {
+        List<Executor> l = new ArrayList<>(target);
+        for (int i = 0; i < current.size(); i++) {
+          Executor executor = current.get(i);
+          if (executor.usage() == 0) {
+            executor.close();
+          } else {
+            l.add(executor);
+          }
+        }
+        if (l.size() < target) {
+          for (int i = l.size(); i < target; i++) {
+            l.add(factory.get());
+          }
+        }
+        current.clear();
+        current.addAll(l);
+        LOGGER.debug("New list is {}", current);
+      }
+    }
+  }
+
+  private Executor newExecutor() {
+    return new Executor(Executors.newSingleThreadExecutor(threadFactory));
+  }
+
+  @Override
+  public synchronized ExecutorService get() {
+    if (closed.get()) {
+      throw new IllegalStateException("Executor service factory is closed");
+    } else {
+      maybeResize(this.executors, this.minSize, this.clientPerExecutor, this.executorFactory);
+      LOGGER.debug("Looking least used executor in {}", this.executors);
+      Executor executor = this.executors.stream().min(EXECUTOR_COMPARATOR).get();
+      LOGGER.debug("Least used executor is {}", executor);
+      executor.incrementUsage();
+      return executor.executorService;
+    }
+  }
+
+  @Override
+  public synchronized void clientClosed(ExecutorService executorService) {
+    if (!closed.get()) {
+      Executor executor = find(executorService);
+      if (executor == null) {
+        LOGGER.info("Could not find executor service wrapper");
+      } else {
+        executor.decrementUsage();
+        maybeResize(this.executors, this.minSize, this.clientPerExecutor, this.executorFactory);
+      }
+    }
+  }
+
+  private Executor find(ExecutorService executorService) {
+    for (Executor executor : this.executors) {
+      if (executor.executorService.equals(executorService)) {
+        return executor;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public synchronized void close() {
+    if (closed.compareAndSet(false, true)) {
+      this.executors.forEach(executor -> executor.executorService.shutdownNow());
+    }
+  }
+
+  static class Executor {
+
+    private final ExecutorService executorService;
+    private AtomicInteger usage = new AtomicInteger(0);
+
+    Executor(ExecutorService executorService) {
+      this.executorService = executorService;
+    }
+
+    Executor incrementUsage() {
+      this.usage.incrementAndGet();
+      return this;
+    }
+
+    Executor decrementUsage() {
+      this.usage.decrementAndGet();
+      return this;
+    }
+
+    Executor addUsage(int delta) {
+      this.usage.addAndGet(delta);
+      return this;
+    }
+
+    Executor substractUsage(int delta) {
+      this.usage.addAndGet(-delta);
+      return this;
+    }
+
+    private int usage() {
+      return this.usage.get();
+    }
+
+    private void close() {
+      this.executorService.shutdownNow();
+    }
+
+    @Override
+    public String toString() {
+      return "Executor{" + "usage=" + usage.get() + '}';
+    }
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/impl/ExecutorServiceFactory.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ExecutorServiceFactory.java
@@ -1,0 +1,26 @@
+// Copyright (c) 2023 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import java.util.concurrent.ExecutorService;
+
+interface ExecutorServiceFactory extends AutoCloseable {
+
+  ExecutorService get();
+
+  void clientClosed(ExecutorService executorService);
+
+  @Override
+  void close();
+}

--- a/src/test/java/com/rabbitmq/stream/impl/ClientFlowControlTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ClientFlowControlTest.java
@@ -1,0 +1,79 @@
+// Copyright (c) 2023 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import static com.rabbitmq.stream.impl.TestUtils.ResponseConditions.ok;
+import static com.rabbitmq.stream.impl.TestUtils.b;
+import static com.rabbitmq.stream.impl.TestUtils.latchAssert;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rabbitmq.stream.OffsetSpecification;
+import com.rabbitmq.stream.impl.Client.ClientParameters;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(TestUtils.StreamTestInfrastructureExtension.class)
+public class ClientFlowControlTest {
+
+  String stream;
+  TestUtils.ClientFactory cf;
+
+  @Test
+  void longProcessingShouldNotBlockOtherServerFrames(TestInfo info) {
+    int messageCount = 100_000;
+    AtomicInteger processedCount = new AtomicInteger(0);
+    TestUtils.publishAndWaitForConfirms(cf, messageCount, stream);
+    CountDownLatch metadataLatch = new CountDownLatch(1);
+    AtomicReference<String> deletedStream = new AtomicReference<>();
+    Client consumerClient =
+        cf.get(
+            new ClientParameters()
+                .chunkListener(
+                    (client, subscriptionId, offset, msgCount, dataSize) ->
+                        client.credit(subscriptionId, 1))
+                .messageListener(
+                    (subscriptionId, offset, chunkTimestamp, committedChunkId, message) -> {
+                      try {
+                        Thread.sleep(1000);
+                      } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                      }
+                      processedCount.incrementAndGet();
+                    })
+                .metadataListener(
+                    (stream, code) -> {
+                      deletedStream.set(stream);
+                      metadataLatch.countDown();
+                    }));
+
+    String toBeDeletedStream = TestUtils.streamName(info);
+    assertThat(consumerClient.create(toBeDeletedStream)).is(ok());
+    assertThat(
+            consumerClient.subscribe(
+                TestUtils.b(0), toBeDeletedStream, OffsetSpecification.first(), 1))
+        .is(ok());
+    assertThat(consumerClient.subscribe(TestUtils.b(1), stream, OffsetSpecification.first(), 1))
+        .is(ok());
+
+    Client deletionClient = cf.get();
+    assertThat(deletionClient.delete(toBeDeletedStream)).is(ok());
+    assertThat(latchAssert(metadataLatch)).completes();
+    assertThat(deletedStream).hasValue(toBeDeletedStream);
+    assertThat(consumerClient.unsubscribe(b(1))).is(ok());
+    assertThat(processedCount).hasValueLessThan(messageCount);
+  }
+}

--- a/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
@@ -143,6 +143,7 @@ public class ConsumersCoordinatorTest {
             return super.shutdownListener(shutdownListener);
           }
         };
+    clientParameters.executorServiceFactory(new DefaultExecutorServiceFactory());
     mocks = MockitoAnnotations.openMocks(this);
     when(environment.locator()).thenReturn(locator);
     when(environment.locatorOperation(any())).thenCallRealMethod();

--- a/src/test/java/com/rabbitmq/stream/impl/DefaultExecutorServiceFactoryTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/DefaultExecutorServiceFactoryTest.java
@@ -1,0 +1,126 @@
+// Copyright (c) 2023 VMware, Inc. or its affiliates.  All rights reserved.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import static com.rabbitmq.stream.impl.DefaultExecutorServiceFactory.maybeResize;
+import static java.util.Arrays.asList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.rabbitmq.stream.impl.DefaultExecutorServiceFactory.Executor;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class DefaultExecutorServiceFactoryTest {
+
+  int minSize = 4;
+  int clientsPerExecutor = 10;
+
+  @Mock Supplier<Executor> factory;
+  @Mock ExecutorService executorService;
+  AutoCloseable mocks;
+  List<Executor> executors;
+
+  @BeforeEach
+  void init() {
+    mocks = MockitoAnnotations.openMocks(this);
+    when(factory.get()).thenReturn(new Executor(executorService));
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @Test
+  void resizeShouldDoNothingWhenClientsPerExecutorIsOkForAll() {
+    executors =
+        executors(
+            executor().addUsage(5),
+            executor().addUsage(5),
+            executor().addUsage(5),
+            executor().addUsage(5));
+    maybeResize(executors, minSize, clientsPerExecutor, factory);
+    assertThat(executors).hasSize(4);
+    verify(factory, never()).get();
+    verify(executorService, never()).shutdownNow();
+  }
+
+  @Test
+  void resizeShouldIncreaseIfMoreClientsPerExecutorForOneExecutor() {
+    executors =
+        executors(
+            executor().addUsage(clientsPerExecutor),
+            executor().addUsage(clientsPerExecutor),
+            executor().addUsage(clientsPerExecutor + 1),
+            executor().addUsage(clientsPerExecutor));
+    maybeResize(executors, minSize, clientsPerExecutor, factory);
+    assertThat(executors).hasSize(5);
+    verify(factory, times(1)).get();
+    verify(executorService, never()).shutdownNow();
+  }
+
+  @RepeatedTest(10)
+  void resizeShouldDecreaseIfFewerClientsPerExecutorAndUnusedExecutor() {
+    // repeated because the initial list is shuffled
+    executors =
+        executors(
+            executor().addUsage(5),
+            executor().addUsage(5),
+            executor().addUsage(5),
+            executor(),
+            executor().addUsage(5));
+    maybeResize(executors, minSize, clientsPerExecutor, factory);
+    assertThat(executors).hasSize(4);
+    verify(factory, never()).get();
+    verify(executorService, times(1)).shutdownNow();
+  }
+
+  @Test
+  void resizeShouldNotResizeIfNoUnusedExecutor() {
+    executors =
+        executors(
+            executor().addUsage(5),
+            executor().addUsage(5),
+            executor().addUsage(5),
+            executor().addUsage(1),
+            executor().addUsage(5));
+    maybeResize(executors, minSize, clientsPerExecutor, factory);
+    assertThat(executors).hasSize(5);
+    verify(factory, never()).get();
+    verify(executorService, never()).shutdownNow();
+  }
+
+  private Executor executor() {
+    return new Executor(executorService);
+  }
+
+  private List<Executor> executors(Executor... executors) {
+    List<Executor> l = asList(executors);
+    Collections.shuffle(l);
+    return new CopyOnWriteArrayList<>(l);
+  }
+}


### PR DESCRIPTION
Each connection has now a dedicated single-threaded executor to dispatch messages. This is especially suited
for long consumers, as they could block the handling of other frames sent by the server.

Other server frames are now handled by a shared executor service. The default implementation maintains a list of executor services shared between all connections maintained by the environment instances. The list grows and shrinks depending on the usage.