### PR TITLE
Make subscription initial credits configurable

### DIFF
--- a/src/main/java/com/rabbitmq/stream/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/ConsumerBuilder.java
@@ -152,6 +152,13 @@ public interface ConsumerBuilder {
   ConsumerBuilder noTrackingStrategy();
 
   /**
+   * Configure flow of messages.
+   *
+   * @return the flow configuration
+   */
+  FlowConfiguration flow();
+
+  /**
    * Create the configured {@link Consumer}
    *
    * @return the configured consumer
@@ -201,6 +208,27 @@ public interface ConsumerBuilder {
      * @return the auto-tracking strategy
      */
     AutoTrackingStrategy flushInterval(Duration flushInterval);
+
+    /**
+     * Go back to the builder.
+     *
+     * @return the consumer builder
+     */
+    ConsumerBuilder builder();
+  }
+
+  /** Message flow configuration. */
+  interface FlowConfiguration {
+
+    /**
+     * The number of initial credits for the subscription.
+     *
+     * <p>Default is 1.
+     *
+     * @param initialCredits the number of initial credits
+     * @return this configuration instance
+     */
+    FlowConfiguration initialCredits(int initialCredits);
 
     /**
      * Go back to the builder.

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -1113,7 +1113,7 @@ public class Client implements AutoCloseable {
    * @param subscriptionId identifier to correlate inbound messages to this subscription
    * @param stream the stream to consume from
    * @param offsetSpecification the specification of the offset to consume from
-   * @param credit the initial number of credits
+   * @param initialCredits the initial number of credits
    * @param properties some optional properties to describe the subscription
    * @return the subscription confirmation
    */
@@ -1121,9 +1121,9 @@ public class Client implements AutoCloseable {
       byte subscriptionId,
       String stream,
       OffsetSpecification offsetSpecification,
-      int credit,
+      int initialCredits,
       Map<String, String> properties) {
-    if (credit < 0 || credit > Short.MAX_VALUE) {
+    if (initialCredits < 0 || initialCredits > Short.MAX_VALUE) {
       throw new IllegalArgumentException("Credit value must be between 0 and " + Short.MAX_VALUE);
     }
     int length = 2 + 2 + 4 + 1 + 2 + stream.length() + 2 + 2; // misses the offset
@@ -1152,7 +1152,7 @@ public class Client implements AutoCloseable {
       if (offsetSpecification.isOffset() || offsetSpecification.isTimestamp()) {
         bb.writeLong(offsetSpecification.getOffset());
       }
-      bb.writeShort(credit);
+      bb.writeShort(initialCredits);
       if (properties != null && !properties.isEmpty()) {
         bb.writeInt(properties.size());
         for (Map.Entry<String, String> entry : properties.entrySet()) {

--- a/src/main/java/com/rabbitmq/stream/perf/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/perf/Utils.java
@@ -649,65 +649,6 @@ class Utils {
     }
   }
 
-  static class CreditsTypeConverter implements CommandLine.ITypeConverter<CreditSettings> {
-
-    @Override
-    public CreditSettings convert(String input) {
-      String errorMessage =
-          input + " is not a valid credits setting, " + "valid example values: 20:1, 15";
-      if (input == null || input.trim().isEmpty()) {
-        typeConversionException(errorMessage);
-      }
-      if (input.contains(":") || input.contains("-")) {
-        String separator = input.contains(":") ? ":" : "-";
-        String[] split = input.split(separator);
-        if (split.length != 2) {
-          typeConversionException(errorMessage);
-        } else {
-          int[] credits =
-              Arrays.stream(split)
-                  .mapToInt(Integer::valueOf)
-                  .peek(
-                      c -> {
-                        if (c <= 0) {
-                          typeConversionException("credit values must be positive");
-                        }
-                      })
-                  .toArray();
-          return new CreditSettings(credits[0], credits[1]);
-        }
-      }
-      try {
-        int value = Integer.parseInt(input);
-        if (value <= 0) {
-          typeConversionException("credit values must be positive");
-        }
-        return new CreditSettings(value, 1);
-      } catch (Exception e) {
-        typeConversionException(errorMessage);
-      }
-      return new CreditSettings(10, 1);
-    }
-  }
-
-  static class CreditSettings {
-
-    private final int initial, additional;
-
-    CreditSettings(int initial, int additional) {
-      this.initial = initial;
-      this.additional = additional;
-    }
-
-    int initial() {
-      return this.initial;
-    }
-
-    int additional() {
-      return this.additional;
-    }
-  }
-
   private static void typeConversionException(String message) {
     throw new TypeConversionException(message);
   }

--- a/src/test/java/com/rabbitmq/stream/perf/UtilsTest.java
+++ b/src/test/java/com/rabbitmq/stream/perf/UtilsTest.java
@@ -24,8 +24,6 @@ import static org.junit.jupiter.params.provider.Arguments.of;
 import com.rabbitmq.stream.OffsetSpecification;
 import com.rabbitmq.stream.compression.Compression;
 import com.rabbitmq.stream.perf.Utils.CompressionTypeConverter;
-import com.rabbitmq.stream.perf.Utils.CreditSettings;
-import com.rabbitmq.stream.perf.Utils.CreditsTypeConverter;
 import com.rabbitmq.stream.perf.Utils.MetricsTagsTypeConverter;
 import com.rabbitmq.stream.perf.Utils.NameStrategyConverter;
 import com.rabbitmq.stream.perf.Utils.PatternNameStrategy;
@@ -368,21 +366,6 @@ public class UtilsTest {
                         + "-x 1 -y 2")
                     .split(" ")))
         .isEqualTo("-x 1 -y 2");
-  }
-
-  @ParameterizedTest
-  @CsvSource({"10:1,10,1", "20:10,20,10", "20,20,1", "20-10,20,10"})
-  void creditsConverterOk(String input, int expectedInitial, int expectedAdditional) {
-    CreditSettings credits = new CreditsTypeConverter().convert(input);
-    assertThat(credits.initial()).isEqualTo(expectedInitial);
-    assertThat(credits.additional()).isEqualTo(expectedAdditional);
-  }
-
-  @ParameterizedTest
-  @ValueSource(strings = {"foo", "-20:10", "20:-1"})
-  void creditsConverterKo(String input) {
-    assertThatThrownBy(() -> new CreditsTypeConverter().convert(input))
-        .isInstanceOf(TypeConversionException.class);
   }
 
   @Command(name = "test-command")


### PR DESCRIPTION
Default is 1, but making it higher can help in
some cases, depending on message size, network speed, etc.