### PR TITLE
Enforce entity by connection limit more strictly

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Utils.java
@@ -39,6 +39,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.LongConsumer;
@@ -660,6 +661,15 @@ final class Utils {
 
     boolean get() {
       return this.value;
+    }
+  }
+
+  static <T> T lock(Lock lock, Supplier<T> action) {
+    lock.lock();
+    try {
+      return action.get();
+    } finally {
+      lock.unlock();
     }
   }
 }


### PR DESCRIPTION
Lock producer and consumer creation in respective coordinator. This adds some contention but should be acceptable as creations are not hot and concurrent operations.

Fixes #464