### PR TITLE
Notify SAC when it is no longer active

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -303,12 +303,7 @@ public class Client implements AutoCloseable {
         });
 
     ChannelFuture f;
-    String clientConnectionName =
-        parameters.clientProperties == null
-            ? ""
-            : (parameters.clientProperties.containsKey("connection_name")
-                ? parameters.clientProperties.get("connection_name")
-                : "");
+    String clientConnectionName = parameters.clientProperties.getOrDefault("connection_name", "");
     try {
       LOGGER.debug(
           "Trying to create stream connection to {}:{}, with client connection name '{}'",
@@ -1503,6 +1498,10 @@ public class Client implements AutoCloseable {
     }
     builder.append(" -> ");
     return builder.append(serverAddress()).toString();
+  }
+
+  String clientConnectionName() {
+    return this.clientConnectionName;
   }
 
   private String serverAddress() {

--- a/src/main/java/com/rabbitmq/stream/impl/SuperStreamConsumer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/SuperStreamConsumer.java
@@ -187,6 +187,10 @@ class SuperStreamConsumer implements Consumer {
         "Consumer#store(long) does not work for super streams, use MessageHandler.Context#storeOffset() instead");
   }
 
+  Consumer consumer(String partition) {
+    return this.consumers.get(partition);
+  }
+
   @Override
   public long storedOffset() {
     throw new UnsupportedOperationException(

--- a/src/test/java/com/rabbitmq/stream/impl/Assertions.java
+++ b/src/test/java/com/rabbitmq/stream/impl/Assertions.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2024 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import static org.assertj.core.api.Assertions.fail;
+
+import java.time.Duration;
+import org.assertj.core.api.AbstractObjectAssert;
+
+final class Assertions {
+
+  private Assertions() {}
+
+  static SyncAssert assertThat(TestUtils.Sync sync) {
+    return new SyncAssert(sync);
+  }
+
+  static class SyncAssert extends AbstractObjectAssert<SyncAssert, TestUtils.Sync> {
+
+    private SyncAssert(TestUtils.Sync sync) {
+      super(sync, SyncAssert.class);
+    }
+
+    SyncAssert completes() {
+      return this.completes(TestUtils.DEFAULT_CONDITION_TIMEOUT);
+    }
+
+    SyncAssert completes(Duration timeout) {
+      boolean completed = actual.await(timeout);
+      if (!completed) {
+        fail("Sync timed out after %d ms", timeout.toMillis());
+      }
+      return this;
+    }
+
+    SyncAssert hasCompleted() {
+      if (!this.actual.hasCompleted()) {
+        fail("Sync should have completed but has not");
+      }
+      return this;
+    }
+
+    SyncAssert hasNotCompleted() {
+      if (this.actual.hasCompleted()) {
+        fail("Sync should have not completed");
+      }
+      return this;
+    }
+  }
+}


### PR DESCRIPTION
A single active consumer may not always receive a notification from the broker when it gets inactive. An obvious reason is the consumer connection goes down. It is still possible to call the consumer update listener from the library, which can help applications take an appropriate action when a consumer goes from active to inactive.

This commit implements the call to the listener under such circumstances (connection closed, stream unavailable because restarted, normal consumer closing).