### PR TITLE
Check producer name is less than 256-byte long

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -892,7 +892,7 @@ public class Client implements AutoCloseable {
         (publisherReference == null || publisherReference.isEmpty()
             ? 0
             : publisherReference.length());
-    if (publisherReferenceSize > 256) {
+    if (publisherReferenceSize >= 256) {
       throw new IllegalArgumentException(
           "If specified, publisher reference must less than 256 characters");
     }


### PR DESCRIPTION
And not less than or equal to 256.

See https://github.com/rabbitmq/rabbitmq-server/issues/12499.