### PR TITLE
Connect to any stream member for consumers when using a load balancer

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -33,10 +33,16 @@ jobs:
             -Dclient.key=./tls-gen/basic/result/client_$(hostname)_key.pem
       - name: Test (dynamic-batch publishing)
         run: |
-          ./mvnw verify -Drabbitmqctl.bin=DOCKER:rabbitmq \
+          ./mvnw test -Drabbitmqctl.bin=DOCKER:rabbitmq \
             -Drabbitmq.stream.producer.dynamic.batch=true \
             -Dca.certificate=./tls-gen/basic/result/ca_certificate.pem \
             -Dclient.certificate=./tls-gen/basic/result/client_$(hostname)_certificate.pem \
             -Dclient.key=./tls-gen/basic/result/client_$(hostname)_key.pem
       - name: Stop broker
         run: docker stop rabbitmq && docker rm rabbitmq
+      - name: Start cluster
+        run: ci/start-cluster.sh
+      - name: Test against cluster
+        run: ./mvnw test -Dtest="*ClusterTest" -Drabbitmqctl.bin=DOCKER:rabbitmq0
+      - name: Stop cluster
+        run: docker compose --file ci/cluster/docker-compose.yml down

--- a/ci/cluster/configuration-0/enabled_plugins
+++ b/ci/cluster/configuration-0/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_stream_management].

--- a/ci/cluster/configuration-0/rabbitmq.conf
+++ b/ci/cluster/configuration-0/rabbitmq.conf
@@ -1,0 +1,8 @@
+cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_classic_config
+cluster_formation.classic_config.nodes.1 = rabbit@node0
+cluster_formation.classic_config.nodes.2 = rabbit@node1
+cluster_formation.classic_config.nodes.3 = rabbit@node2
+loopback_users = none
+
+stream.advertised_host = localhost
+stream.advertised_port = 5552

--- a/ci/cluster/configuration-1/enabled_plugins
+++ b/ci/cluster/configuration-1/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_stream_management].

--- a/ci/cluster/configuration-1/rabbitmq.conf
+++ b/ci/cluster/configuration-1/rabbitmq.conf
@@ -1,0 +1,8 @@
+cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_classic_config
+cluster_formation.classic_config.nodes.1 = rabbit@node0
+cluster_formation.classic_config.nodes.2 = rabbit@node1
+cluster_formation.classic_config.nodes.3 = rabbit@node2
+loopback_users = none
+
+stream.advertised_host = localhost
+stream.advertised_port = 5553

--- a/ci/cluster/configuration-2/enabled_plugins
+++ b/ci/cluster/configuration-2/enabled_plugins
@@ -1,0 +1,1 @@
+[rabbitmq_stream_management].

--- a/ci/cluster/configuration-2/rabbitmq.conf
+++ b/ci/cluster/configuration-2/rabbitmq.conf
@@ -1,0 +1,8 @@
+cluster_formation.peer_discovery_backend  = rabbit_peer_discovery_classic_config
+cluster_formation.classic_config.nodes.1 = rabbit@node0
+cluster_formation.classic_config.nodes.2 = rabbit@node1
+cluster_formation.classic_config.nodes.3 = rabbit@node2
+loopback_users = none
+
+stream.advertised_host = localhost
+stream.advertised_port = 5554

--- a/ci/cluster/docker-compose.yml
+++ b/ci/cluster/docker-compose.yml
@@ -1,0 +1,64 @@
+services:
+  node0:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+    networks:
+      - rabbitmq-cluster
+    hostname: node0
+    container_name: rabbitmq0
+    image: ${RABBITMQ_IMAGE:-rabbitmq:4.0}
+    pull_policy: always
+    ports:
+      - "5672:5672"
+      - "5552:5552"
+      - "15672:15672"
+    tty: true
+    volumes:
+      - ./configuration-0/:/etc/rabbitmq/
+  node1:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+    networks:
+      - rabbitmq-cluster
+    hostname: node1
+    container_name: rabbitmq1
+    image: ${RABBITMQ_IMAGE:-rabbitmq:4.0}
+    pull_policy: always
+    ports:
+      - "5673:5672"
+      - "5553:5552"
+      - "15673:15672"
+    tty: true
+    volumes:
+      - ./configuration-1/:/etc/rabbitmq/
+  node2:
+    environment:
+      - RABBITMQ_ERLANG_COOKIE='secret_cookie'
+    networks:
+      - rabbitmq-cluster
+    hostname: node2
+    container_name: rabbitmq2
+    image: ${RABBITMQ_IMAGE:-rabbitmq:4.0}
+    pull_policy: always
+    ports:
+      - "5674:5672"
+      - "5554:5552"
+      - "15674:15672"
+    tty: true
+    volumes:
+      - ./configuration-2/:/etc/rabbitmq/
+  load-balander:
+    networks:
+      - rabbitmq-cluster
+    hostname: load-balancer
+    container_name: haproxy
+    image: haproxy:3.0
+    pull_policy: always
+    ports:
+      - "5555:5555"
+      - "8100:8100"
+    tty: true
+    volumes:
+      - ./load-balancer/:/usr/local/etc/haproxy:ro
+networks:
+  rabbitmq-cluster:

--- a/ci/cluster/load-balancer/haproxy.cfg
+++ b/ci/cluster/load-balancer/haproxy.cfg
@@ -1,0 +1,31 @@
+global
+        log 127.0.0.1   local0 info
+        maxconn 512
+
+defaults
+        log     global
+        mode    tcp
+        option  tcplog
+        option  dontlognull
+        retries 3
+        option redispatch
+        maxconn 512
+        timeout connect 5s
+        timeout client 120s
+        timeout server 120s
+
+listen stream
+        bind :5555
+        mode tcp
+        balance roundrobin
+        server rabbitmq-0 node0:5552
+        server rabbitmq-1 node1:5552
+        server rabbitmq-2 node2:5552
+
+listen  stats
+        bind :8100
+        mode http
+        option httplog
+        stats enable
+        stats uri       /stats
+        stats refresh 5s

--- a/ci/start-cluster.sh
+++ b/ci/start-cluster.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+export RABBITMQ_IMAGE=${RABBITMQ_IMAGE:-rabbitmq:4.0}
+
+wait_for_message() {
+  while ! docker logs "$1" | grep -q "$2";
+  do
+      sleep 2
+      echo "Waiting 2 seconds for $1 to start..."
+  done
+}
+
+docker compose --file ci/cluster/docker-compose.yml down
+docker compose --file ci/cluster/docker-compose.yml up --detach
+
+wait_for_message rabbitmq0 "completed with"
+
+docker exec rabbitmq0 rabbitmqctl await_online_nodes 3
+
+docker exec rabbitmq0 rabbitmqctl enable_feature_flag --opt-in khepri_db
+docker exec rabbitmq1 rabbitmqctl enable_feature_flag --opt-in khepri_db
+docker exec rabbitmq2 rabbitmqctl enable_feature_flag --opt-in khepri_db
+
+docker exec rabbitmq0 rabbitmqctl cluster_status
+
+docker compose --file ci/cluster/docker-compose.yml ps

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -219,7 +219,8 @@ class StreamEnvironment implements Environment {
             maxConsumersByConnection,
             connectionNamingStrategy,
             Utils.coordinatorClientFactory(this),
-            forceReplicaForConsumers);
+            forceReplicaForConsumers,
+            Utils.brokerPicker());
     this.offsetTrackingCoordinator = new OffsetTrackingCoordinator(this);
     ClientParameters clientParametersForInit = locatorParametersCopy();
     Runnable locatorInitSequence =

--- a/src/test/java/com/rabbitmq/stream/Host.java
+++ b/src/test/java/com/rabbitmq/stream/Host.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -118,7 +118,7 @@ public class Host {
     return executeCommand(rabbitmqStreamsCommand() + " " + command);
   }
 
-  public static Process rabbitmqctlIgnoreError(String command) throws IOException {
+  public static Process rabbitmqctlIgnoreError(String command) {
     return executeCommand(rabbitmqctlCommand() + " " + command, true);
   }
 

--- a/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
@@ -15,8 +15,7 @@
 package com.rabbitmq.stream.impl;
 
 import static com.rabbitmq.stream.BackOffDelayPolicy.fixedWithInitialDelay;
-import static com.rabbitmq.stream.impl.ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT;
-import static com.rabbitmq.stream.impl.ConsumersCoordinator.pickSlot;
+import static com.rabbitmq.stream.impl.ConsumersCoordinator.*;
 import static com.rabbitmq.stream.impl.TestUtils.b;
 import static com.rabbitmq.stream.impl.TestUtils.latchAssert;
 import static com.rabbitmq.stream.impl.TestUtils.metadata;
@@ -25,6 +24,9 @@ import static com.rabbitmq.stream.impl.TestUtils.waitAtMost;
 import static com.rabbitmq.stream.impl.Utils.brokerPicker;
 import static java.lang.String.format;
 import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.IntStream.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -53,8 +55,7 @@ import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -441,17 +442,58 @@ public class ConsumersCoordinatorTest {
   }
 
   @Test
-  void findBrokersForStreamShouldReturnLeaderIfNoReplicas() {
+  void findCandidateNodesShouldReturnLeaderIfNoReplicas() {
     when(locator.metadata("stream")).thenReturn(metadata(leader(), null));
-    assertThat(coordinator.findBrokersForStream("stream", false)).hasSize(1).contains(leader());
+    assertThat(coordinator.findCandidateNodes("stream", false))
+        .hasSize(1)
+        .contains(leaderWrapper());
   }
 
   @Test
-  void findBrokersForStreamShouldReturnReplicasIfThereAreSome() {
+  void findCandidateNodesShouldReturnReplicasIfThereAreSome() {
     when(locator.metadata("stream")).thenReturn(metadata(null, replicas()));
-    assertThat(coordinator.findBrokersForStream("stream", false))
+    assertThat(coordinator.findCandidateNodes("stream", false))
         .hasSize(2)
-        .hasSameElementsAs(replicas());
+        .hasSameElementsAs(replicaWrappers());
+  }
+
+  @Test
+  void findCandidateNodesShouldReturnLeaderAndReplicasIfForceReplicaIsFalse() {
+    when(locator.metadata("stream")).thenReturn(metadata(leader(), replicas()));
+    assertThat(coordinator.findCandidateNodes("stream", false))
+        .hasSize(3)
+        .contains(leaderWrapper())
+        .containsAll(replicaWrappers());
+  }
+
+  @Test
+  void findCandidateNodesShouldReturnOnlyReplicasIfForceReplicaIsTrue() {
+    when(locator.metadata("stream")).thenReturn(metadata(leader(), replicas()));
+    assertThat(coordinator.findCandidateNodes("stream", true))
+        .hasSize(2)
+        .containsAll(replicaWrappers());
+  }
+
+  @Test
+  void pickBrokerShouldPreferReplicas() {
+    Client.Broker leader = leader();
+    List<Client.Broker> replicas = replicas();
+    AtomicInteger sequence = new AtomicInteger();
+    Function<List<Client.Broker>, Client.Broker> picker =
+        candidates -> candidates.get(sequence.getAndIncrement() % candidates.size());
+    // never pick a leader if replicas are available
+    List<Utils.BrokerWrapper> leaderAndOneReplica =
+        Arrays.asList(leaderWrapper(), replicaWrappers().get(0));
+    range(0, 10)
+        .forEach(
+            ignored -> {
+              Client.Broker picked = pickBroker(picker, nodeWrappers());
+              assertThat(picked).isNotEqualTo(leader).isIn(replicas);
+              picked = pickBroker(picker, leaderAndOneReplica);
+              assertThat(picked).isNotEqualTo(leader).isIn(replicas);
+            });
+    // pick the leader if it is the only one
+    assertThat(pickBroker(picker, singletonList(leaderWrapper()))).isEqualTo(leader);
   }
 
   @Test
@@ -1150,7 +1192,7 @@ public class ConsumersCoordinatorTest {
             brokerPicker());
 
     List<Runnable> closingRunnables =
-        IntStream.range(0, subscriptionCount)
+        range(0, subscriptionCount)
             .mapToObj(
                 i ->
                     coordinator.subscribe(
@@ -1163,7 +1205,7 @@ public class ConsumersCoordinatorTest {
                         (offset, message) -> {},
                         Collections.emptyMap(),
                         flowStrategy()))
-            .collect(Collectors.toList());
+            .collect(toList());
 
     verify(clientFactory, times(2)).client(any());
     verify(client, times(subscriptionCount))
@@ -1211,7 +1253,7 @@ public class ConsumersCoordinatorTest {
     int extraSubscriptionCount = ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT / 5;
     int subscriptionCount =
         ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT + extraSubscriptionCount;
-    IntStream.range(0, subscriptionCount)
+    range(0, subscriptionCount)
         .forEach(
             i -> {
               coordinator.subscribe(
@@ -1276,7 +1318,7 @@ public class ConsumersCoordinatorTest {
     int extraSubscriptionCount = ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT / 5;
     int subscriptionCount =
         ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT + extraSubscriptionCount;
-    IntStream.range(0, subscriptionCount)
+    range(0, subscriptionCount)
         .forEach(
             i -> {
               coordinator.subscribe(
@@ -2039,7 +2081,7 @@ public class ConsumersCoordinatorTest {
   @Test
   void pickSlotTest() {
     List<String> list = new ArrayList<>(ConsumersCoordinator.MAX_SUBSCRIPTIONS_PER_CLIENT);
-    IntStream.range(0, MAX_SUBSCRIPTIONS_PER_CLIENT).forEach(ignored -> list.add(null));
+    range(0, MAX_SUBSCRIPTIONS_PER_CLIENT).forEach(ignored -> list.add(null));
     AtomicInteger sequence = new AtomicInteger(0);
     int index = pickSlot(list, sequence);
     assertThat(index).isZero();
@@ -2077,12 +2119,26 @@ public class ConsumersCoordinatorTest {
     assertThat(index).isEqualTo(5);
   }
 
-  Client.Broker leader() {
+  static Client.Broker leader() {
     return new Client.Broker("leader", -1);
   }
 
-  List<Client.Broker> replicas() {
+  static Utils.BrokerWrapper leaderWrapper() {
+    return new Utils.BrokerWrapper(leader(), true);
+  }
+
+  static List<Client.Broker> replicas() {
     return Arrays.asList(new Client.Broker("replica1", -1), new Client.Broker("replica2", -1));
+  }
+
+  static List<Utils.BrokerWrapper> nodeWrappers() {
+    List<Utils.BrokerWrapper> wrappers = new ArrayList<>(replicaWrappers());
+    wrappers.add(leaderWrapper());
+    return wrappers;
+  }
+
+  static List<Utils.BrokerWrapper> replicaWrappers() {
+    return replicas().stream().map(b -> new Utils.BrokerWrapper(b, false)).collect(toList());
   }
 
   List<Client.Broker> replica() {

--- a/src/test/java/com/rabbitmq/stream/impl/LoadBalancerClusterTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/LoadBalancerClusterTest.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2024 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import static java.lang.Integer.parseInt;
+import static java.util.stream.Collectors.toSet;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.rabbitmq.stream.Address;
+import com.rabbitmq.stream.ConsumerFlowStrategy;
+import com.rabbitmq.stream.OffsetSpecification;
+import com.rabbitmq.stream.SubscriptionListener;
+import com.rabbitmq.stream.impl.MonitoringTestUtils.ConsumerCoordinatorInfo;
+import com.rabbitmq.stream.impl.TestUtils.DisabledIfNotCluster;
+import io.netty.channel.EventLoopGroup;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+@DisabledIfNotCluster
+@StreamTestInfrastructure
+public class LoadBalancerClusterTest {
+
+  private static final int LB_PORT = 5555;
+  private static final SubscriptionListener NO_OP_SUBSCRIPTION_LISTENER = subscriptionContext -> {};
+  private static final Runnable NO_OP_TRACKING_CLOSING_CALLBACK = () -> {};
+
+  @Mock StreamEnvironment environment;
+  @Mock StreamConsumer consumer;
+  AutoCloseable mocks;
+  TestUtils.ClientFactory cf;
+  String stream;
+  EventLoopGroup eventLoopGroup;
+  Client locator;
+
+  @BeforeEach
+  void init() {
+    mocks = MockitoAnnotations.openMocks(this);
+    locator = cf.get(new Client.ClientParameters().port(LB_PORT));
+    when(environment.locator()).thenReturn(locator);
+    when(environment.clientParametersCopy())
+        .thenReturn(new Client.ClientParameters().eventLoopGroup(eventLoopGroup).port(LB_PORT));
+    Address loadBalancerAddress = new Address("localhost", LB_PORT);
+    when(environment.addressResolver()).thenReturn(address -> loadBalancerAddress);
+    when(environment.locatorOperation(any())).thenCallRealMethod();
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  void pickConsumersAmongCandidates(boolean forceReplica) {
+    int maxSubscriptionsPerClient = 2;
+    int subscriptionCount = maxSubscriptionsPerClient * 10;
+    try (ConsumersCoordinator c =
+        new ConsumersCoordinator(
+            environment,
+            maxSubscriptionsPerClient,
+            type -> "consumer-connection",
+            Utils.coordinatorClientFactory(this.environment, Duration.ofMillis(10)),
+            forceReplica,
+            Utils.brokerPicker())) {
+
+      IntStream.range(0, subscriptionCount)
+          .forEach(
+              ignored -> {
+                c.subscribe(
+                    consumer,
+                    stream,
+                    OffsetSpecification.first(),
+                    null,
+                    NO_OP_SUBSCRIPTION_LISTENER,
+                    NO_OP_TRACKING_CLOSING_CALLBACK,
+                    (offset, message) -> {},
+                    Collections.emptyMap(),
+                    flowStrategy());
+              });
+
+      Client.StreamMetadata metadata = locator.metadata(stream).get(stream);
+      Set<Client.Broker> allowedNodes = new HashSet<>(metadata.getReplicas());
+      if (!forceReplica) {
+        allowedNodes.add(metadata.getLeader());
+      }
+
+      ConsumerCoordinatorInfo info = MonitoringTestUtils.extract(c);
+      assertThat(info.consumerCount()).isEqualTo(subscriptionCount);
+      Set<Client.Broker> usedNodes =
+          info.clients().stream()
+              .map(m -> m.node().split(":"))
+              .map(np -> new Client.Broker(np[0], parseInt(np[1])))
+              .collect(toSet());
+      assertThat(usedNodes).hasSameSizeAs(allowedNodes).containsAll(allowedNodes);
+    }
+  }
+
+  private static ConsumerFlowStrategy flowStrategy() {
+    return ConsumerFlowStrategy.creditOnChunkArrival(10);
+  }
+}

--- a/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
+++ b/src/test/java/com/rabbitmq/stream/impl/MonitoringTestUtils.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -130,7 +130,11 @@ class MonitoringTestUtils {
     }
 
     public int getConsumerCount() {
-      return consumer_count;
+      return this.consumer_count;
+    }
+
+    public String node() {
+      return this.node;
     }
 
     @Override

--- a/src/test/java/com/rabbitmq/stream/impl/StreamTestInfrastructure.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamTestInfrastructure.java
@@ -1,0 +1,24 @@
+// Copyright (c) 2024 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import java.lang.annotation.*;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@ExtendWith(TestUtils.StreamTestInfrastructureExtension.class)
+public @interface StreamTestInfrastructure {}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -7,7 +7,7 @@
 
     <logger name="com.rabbitmq.stream" level="warn" />
     <logger name="com.rabbitmq.stream.impl.Utils" level="warn" />
-    <logger name="com.rabbitmq.stream.impl.ProducersCoordinator" level="warn" />
+    <logger name="com.rabbitmq.stream.impl.ConsumersCoordinator" level="warn" />
 
     <logger name="com.rabbitmq.stream.perf.Version" level="error" />
 

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -6,6 +6,8 @@
     </appender>
 
     <logger name="com.rabbitmq.stream" level="warn" />
+    <logger name="com.rabbitmq.stream.impl.Utils" level="warn" />
+    <logger name="com.rabbitmq.stream.impl.ProducersCoordinator" level="warn" />
 
     <logger name="com.rabbitmq.stream.perf.Version" level="error" />
 


### PR DESCRIPTION
Favor replica nodes, but fall back to any stream member if the picked node is the expected one. This should happen only with a load balancer. This reduces the time to create a consumer, because there will be fewer retry attempts.
