### PR TITLE
Add option to connect to a replica for producers

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -220,6 +220,11 @@ The client retries 5 times before falling back to the stream leader node.
 Set to `true` only for clustered environments, not for 1-node environments, where only the stream leader is available.
 |`false`
 
+|`forceLeaderForProducers`
+|Force connecting to a stream leader for producers.
+Set to `false` if it acceptable to stay connected to a stream replica when a load balancer is in use.
+|`true`
+
 |`id`
 |Informational ID for the environment instance.
 Used as a prefix for connection names.

--- a/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -354,7 +354,7 @@ public interface EnvironmentBuilder {
    * <p><b>Do not set this flag to <code>true</code> when streams have only 1 member (the leader),
    * e.g. for local development.</b>
    *
-   * <p>Default is false.
+   * <p>Default is <code>false</code>.
    *
    * @param forceReplica whether to force the connection to a replica or not
    * @return this builder instance
@@ -363,6 +363,37 @@ public interface EnvironmentBuilder {
    * @since 0.13.0
    */
   EnvironmentBuilder forceReplicaForConsumers(boolean forceReplica);
+
+  /**
+   * Flag to force the connection to the stream leader for producers.
+   *
+   * <p>The library prefers to connect to a node that hosts a stream leader for producers (default
+   * behavior).
+   *
+   * <p>When using a load balancer, the library does not know in advance the node it connects to. It
+   * may have to retry to connect to the appropriate node.
+   *
+   * <p>It will retry until it connects to the appropriate node (flag set to <code>true</code>, the
+   * default). This provides the best data locality, but may require several attempts, delaying the
+   * creation or the recovery of producers. This usually suits high-throughput use cases.
+   *
+   * <p>The library will accept the connection to a stream replica if the flag is set to <code>false
+   * </code>. This will speed up the creation/recovery of producers, but at the cost of network hops
+   * between cluster nodes when publishing messages because only a stream leader accepts writes.
+   * This is usually acceptable for low-throughput use cases.
+   *
+   * <p>Changing the default value should only benefit systems where a load balancer sits between
+   * the client applications and the cluster nodes.
+   *
+   * <p>Default is <code>true</code>.
+   *
+   * @param forceLeader whether to force the connection to the leader or not
+   * @return this builder instance
+   * @see #recoveryBackOffDelayPolicy(BackOffDelayPolicy)
+   * @see #topologyUpdateBackOffDelayPolicy(BackOffDelayPolicy)
+   * @since 0.21.0
+   */
+  EnvironmentBuilder forceLeaderForProducers(boolean forceLeader);
 
   /**
    * Create the {@link Environment} instance.

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -2245,7 +2245,10 @@ public class Client implements AutoCloseable {
       this.stream = stream;
       this.responseCode = responseCode;
       this.leader = leader;
-      this.replicas = replicas == null ? null : Collections.unmodifiableList(replicas);
+      this.replicas =
+          (replicas == null || replicas.isEmpty())
+              ? Collections.emptyList()
+              : Collections.unmodifiableList(replicas);
     }
 
     public short getResponseCode() {

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -2263,9 +2263,12 @@ public class Client implements AutoCloseable {
       return leader;
     }
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public List<Broker> getReplicas() {
-      return replicas;
+      return this.replicas.isEmpty() ? Collections.emptyList() : new ArrayList<>(this.replicas);
+    }
+
+    boolean hasReplicas() {
+      return !this.replicas.isEmpty();
     }
 
     public String getStream() {

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -2263,6 +2263,7 @@ public class Client implements AutoCloseable {
       return leader;
     }
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     public List<Broker> getReplicas() {
       return replicas;
     }

--- a/src/main/java/com/rabbitmq/stream/impl/ProducersCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ProducersCoordinator.java
@@ -224,7 +224,7 @@ final class ProducersCoordinator implements AutoCloseable {
     }
     candidates.add(new BrokerWrapper(leader, true));
 
-    if (!forceLeader && !streamMetadata.getReplicas().isEmpty()) {
+    if (!forceLeader && streamMetadata.hasReplicas()) {
       candidates.addAll(
           streamMetadata.getReplicas().stream()
               .map(b -> new BrokerWrapper(b, false))

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -102,7 +102,10 @@ class StreamEnvironment implements Environment {
       Function<ClientConnectionType, String> connectionNamingStrategy,
       Function<Client.ClientParameters, Client> clientFactory,
       ObservationCollector<?> observationCollector,
-      boolean forceReplicaForConsumers) {
+      boolean forceReplicaForConsumers,
+      boolean forceLeaderForProducers,
+      Duration producerNodeRetryDelay,
+      Duration consumerNodeRetryDelay) {
     this.recoveryBackOffDelayPolicy = recoveryBackOffDelayPolicy;
     this.topologyUpdateBackOffDelayPolicy = topologyBackOffDelayPolicy;
     this.byteBufAllocator = byteBufAllocator;
@@ -212,13 +215,14 @@ class StreamEnvironment implements Environment {
             maxProducersByConnection,
             maxTrackingConsumersByConnection,
             connectionNamingStrategy,
-            Utils.coordinatorClientFactory(this));
+            Utils.coordinatorClientFactory(this, producerNodeRetryDelay),
+            forceLeaderForProducers);
     this.consumersCoordinator =
         new ConsumersCoordinator(
             this,
             maxConsumersByConnection,
             connectionNamingStrategy,
-            Utils.coordinatorClientFactory(this),
+            Utils.coordinatorClientFactory(this, consumerNodeRetryDelay),
             forceReplicaForConsumers,
             Utils.brokerPicker());
     this.offsetTrackingCoordinator = new OffsetTrackingCoordinator(this);

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironmentBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -65,8 +65,11 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
   private CompressionCodecFactory compressionCodecFactory;
   private boolean lazyInit = false;
   private boolean forceReplicaForConsumers = false;
+  private boolean forceLeaderForProducers = true;
   private Function<Client.ClientParameters, Client> clientFactory = Client::new;
   private ObservationCollector<?> observationCollector = ObservationCollector.NO_OP;
+  private Duration producerNodeRetryDelay = Duration.ofMillis(500);
+  private Duration consumerNodeRetryDelay = Duration.ofMillis(1000);
 
   public StreamEnvironmentBuilder() {}
 
@@ -275,6 +278,12 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
   }
 
   @Override
+  public EnvironmentBuilder forceLeaderForProducers(boolean forceLeader) {
+    this.forceLeaderForProducers = forceLeader;
+    return this;
+  }
+
+  @Override
   public TlsConfiguration tls() {
     this.tls.enable();
     return this.tls;
@@ -293,6 +302,16 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
   @Override
   public EnvironmentBuilder observationCollector(ObservationCollector<?> observationCollector) {
     this.observationCollector = observationCollector;
+    return this;
+  }
+
+  StreamEnvironmentBuilder producerNodeRetryDelay(Duration producerNodeRetryDelay) {
+    this.producerNodeRetryDelay = producerNodeRetryDelay;
+    return this;
+  }
+
+  StreamEnvironmentBuilder consumerNodeRetryDelay(Duration consumerNodeRetryDelay) {
+    this.consumerNodeRetryDelay = consumerNodeRetryDelay;
     return this;
   }
 
@@ -327,7 +346,10 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
         connectionNamingStrategy,
         this.clientFactory,
         this.observationCollector,
-        this.forceReplicaForConsumers);
+        this.forceReplicaForConsumers,
+        this.forceLeaderForProducers,
+        this.producerNodeRetryDelay,
+        this.consumerNodeRetryDelay);
   }
 
   static final class DefaultTlsConfiguration implements TlsConfiguration {

--- a/src/main/java/com/rabbitmq/stream/impl/Utils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Utils.java
@@ -135,10 +135,6 @@ final class Utils {
     return (short) (code | 0B1000_0000_0000_0000);
   }
 
-  static ClientFactory coordinatorClientFactory(StreamEnvironment environment) {
-    return coordinatorClientFactory(environment, ConditionalClientFactory.RETRY_INTERVAL);
-  }
-
   static ClientFactory coordinatorClientFactory(
       StreamEnvironment environment, Duration retryInterval) {
     String messageFormat =

--- a/src/test/java/com/rabbitmq/stream/impl/LoadBalancerClusterTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/LoadBalancerClusterTest.java
@@ -14,26 +14,28 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
+import static com.rabbitmq.stream.impl.Assertions.assertThat;
 import static java.lang.Integer.parseInt;
 import static java.util.stream.Collectors.toSet;
+import static java.util.stream.IntStream.range;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.rabbitmq.stream.Address;
-import com.rabbitmq.stream.ConsumerFlowStrategy;
-import com.rabbitmq.stream.OffsetSpecification;
-import com.rabbitmq.stream.SubscriptionListener;
+import com.rabbitmq.stream.*;
+import com.rabbitmq.stream.impl.Client.Broker;
 import com.rabbitmq.stream.impl.MonitoringTestUtils.ConsumerCoordinatorInfo;
+import com.rabbitmq.stream.impl.MonitoringTestUtils.EnvironmentInfo;
+import com.rabbitmq.stream.impl.MonitoringTestUtils.ProducersCoordinatorInfo;
 import com.rabbitmq.stream.impl.TestUtils.DisabledIfNotCluster;
 import io.netty.channel.EventLoopGroup;
 import java.time.Duration;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-import java.util.stream.IntStream;
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
@@ -49,11 +51,13 @@ public class LoadBalancerClusterTest {
 
   @Mock StreamEnvironment environment;
   @Mock StreamConsumer consumer;
+  @Mock StreamProducer producer;
   AutoCloseable mocks;
   TestUtils.ClientFactory cf;
   String stream;
   EventLoopGroup eventLoopGroup;
   Client locator;
+  Address loadBalancerAddress = new Address("localhost", LB_PORT);
 
   @BeforeEach
   void init() {
@@ -62,7 +66,6 @@ public class LoadBalancerClusterTest {
     when(environment.locator()).thenReturn(locator);
     when(environment.clientParametersCopy())
         .thenReturn(new Client.ClientParameters().eventLoopGroup(eventLoopGroup).port(LB_PORT));
-    Address loadBalancerAddress = new Address("localhost", LB_PORT);
     when(environment.addressResolver()).thenReturn(address -> loadBalancerAddress);
     when(environment.locatorOperation(any())).thenCallRealMethod();
   }
@@ -86,7 +89,7 @@ public class LoadBalancerClusterTest {
             forceReplica,
             Utils.brokerPicker())) {
 
-      IntStream.range(0, subscriptionCount)
+      range(0, subscriptionCount)
           .forEach(
               ignored -> {
                 c.subscribe(
@@ -102,19 +105,136 @@ public class LoadBalancerClusterTest {
               });
 
       Client.StreamMetadata metadata = locator.metadata(stream).get(stream);
-      Set<Client.Broker> allowedNodes = new HashSet<>(metadata.getReplicas());
+      Set<Broker> allowedNodes = new HashSet<>(metadata.getReplicas());
       if (!forceReplica) {
         allowedNodes.add(metadata.getLeader());
       }
 
       ConsumerCoordinatorInfo info = MonitoringTestUtils.extract(c);
       assertThat(info.consumerCount()).isEqualTo(subscriptionCount);
-      Set<Client.Broker> usedNodes =
+      Set<Broker> usedNodes =
           info.clients().stream()
               .map(m -> m.node().split(":"))
-              .map(np -> new Client.Broker(np[0], parseInt(np[1])))
+              .map(np -> new Broker(np[0], parseInt(np[1])))
               .collect(toSet());
       assertThat(usedNodes).hasSameSizeAs(allowedNodes).containsAll(allowedNodes);
+    }
+  }
+
+  @Test
+  void pickProducersAmongCandidatesIfInstructed() {
+    boolean forceLeader = true;
+    when(consumer.stream()).thenReturn(stream);
+    int maxAgentPerClient = 2;
+    int agentCount = maxAgentPerClient * 10;
+    try (ProducersCoordinator c =
+        new ProducersCoordinator(
+            environment,
+            maxAgentPerClient,
+            maxAgentPerClient,
+            type -> "producer-connection",
+            Utils.coordinatorClientFactory(this.environment, Duration.ofMillis(10)),
+            forceLeader)) {
+
+      range(0, agentCount)
+          .forEach(
+              ignored -> {
+                c.registerProducer(producer, null, stream);
+                c.registerTrackingConsumer(consumer);
+              });
+
+      Client.StreamMetadata metadata = locator.metadata(stream).get(stream);
+      Set<Broker> allowedNodes = new HashSet<>(Collections.singleton(metadata.getLeader()));
+      if (!forceLeader) {
+        allowedNodes.addAll(metadata.getReplicas());
+      }
+
+      ProducersCoordinatorInfo info = MonitoringTestUtils.extract(c);
+      assertThat(info.producerCount()).isEqualTo(agentCount);
+      assertThat(info.trackingConsumerCount()).isEqualTo(agentCount);
+      Set<Broker> usedNodes =
+          info.nodesConnected().stream()
+              .map(n -> n.split(":"))
+              .map(np -> new Broker(np[0], parseInt(np[1])))
+              .collect(toSet());
+      assertThat(usedNodes).hasSameSizeAs(allowedNodes).containsAll(allowedNodes);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void producersConsumersShouldSpreadAccordingToDataLocalitySettings(boolean forceLocality) {
+    int maxPerConnection = 2;
+    int agentCount = maxPerConnection * 20;
+    StreamEnvironmentBuilder builder = (StreamEnvironmentBuilder) Environment.builder();
+    builder
+        .producerNodeRetryDelay(Duration.ofMillis(10))
+        .consumerNodeRetryDelay(Duration.ofMillis(10));
+    try (Environment env =
+        builder
+            .port(LB_PORT)
+            .forceReplicaForConsumers(forceLocality)
+            .forceReplicaForConsumers(forceLocality)
+            .addressResolver(addr -> loadBalancerAddress)
+            .maxProducersByConnection(maxPerConnection)
+            .maxConsumersByConnection(maxPerConnection)
+            .forceLeaderForProducers(forceLocality)
+            .netty()
+            .eventLoopGroup(eventLoopGroup)
+            .environmentBuilder()
+            .build()) {
+      TestUtils.Sync consumeSync = TestUtils.sync(agentCount * agentCount);
+      Set<Integer> consumersThatReceived = ConcurrentHashMap.newKeySet(agentCount);
+      List<Producer> producers = new ArrayList<>();
+      range(0, agentCount)
+          .forEach(
+              index -> {
+                producers.add(env.producerBuilder().stream(stream).build());
+                env.consumerBuilder().stream(stream)
+                    .messageHandler(
+                        (ctx, msg) -> {
+                          consumersThatReceived.add(index);
+                          consumeSync.down();
+                        })
+                    .offset(OffsetSpecification.first())
+                    .build();
+              });
+      producers.forEach(p -> p.send(p.messageBuilder().build(), ctx -> {}));
+      assertThat(consumeSync).completes();
+      assertThat(consumersThatReceived).containsAll(range(0, agentCount).boxed().collect(toSet()));
+
+      EnvironmentInfo info = MonitoringTestUtils.extract(env);
+      ProducersCoordinatorInfo producerInfo = info.getProducers();
+      ConsumerCoordinatorInfo consumerInfo = info.getConsumers();
+
+      assertThat(producerInfo.producerCount()).isEqualTo(agentCount);
+      assertThat(consumerInfo.consumerCount()).isEqualTo(agentCount);
+
+      Client.StreamMetadata metadata = locator.metadata(stream).get(stream);
+
+      Function<Collection<String>, Set<Broker>> toBrokers =
+          nodes ->
+              nodes.stream()
+                  .map(n -> n.split(":"))
+                  .map(n -> new Broker(n[0], parseInt(n[1])))
+                  .collect(toSet());
+      Set<Broker> usedNodes = toBrokers.apply(producerInfo.nodesConnected());
+      assertThat(usedNodes).contains(metadata.getLeader());
+      if (forceLocality) {
+        assertThat(usedNodes).hasSize(1);
+      } else {
+        assertThat(usedNodes).hasSize(metadata.getReplicas().size() + 1);
+        assertThat(usedNodes).containsAll(metadata.getReplicas());
+      }
+
+      usedNodes = toBrokers.apply(consumerInfo.nodesConnected());
+      assertThat(usedNodes).containsAll(metadata.getReplicas());
+      if (forceLocality) {
+        assertThat(usedNodes).hasSameSizeAs(metadata.getReplicas());
+      } else {
+        assertThat(usedNodes).hasSize(metadata.getReplicas().size() + 1);
+        assertThat(usedNodes).contains(metadata.getLeader());
+      }
     }
   }
 

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentUnitTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -98,7 +98,10 @@ public class StreamEnvironmentUnitTest {
             type -> "locator-connection",
             cf,
             ObservationCollector.NO_OP,
-            false);
+            false,
+            true,
+            Duration.ofMillis(100),
+            Duration.ofMillis(100));
   }
 
   @AfterEach
@@ -163,7 +166,10 @@ public class StreamEnvironmentUnitTest {
             type -> "locator-connection",
             cf,
             ObservationCollector.NO_OP,
-            false);
+            false,
+            true,
+            Duration.ofMillis(100),
+            Duration.ofMillis(100));
     verify(cf, times(3)).apply(any(Client.ClientParameters.class));
   }
 
@@ -191,7 +197,10 @@ public class StreamEnvironmentUnitTest {
             type -> "locator-connection",
             cf,
             ObservationCollector.NO_OP,
-            false);
+            false,
+            true,
+            Duration.ofMillis(100),
+            Duration.ofMillis(100));
     verify(cf, times(expectedConnectionCreation)).apply(any(Client.ClientParameters.class));
   }
 


### PR DESCRIPTION
This can speed up producer creation/recovery when a load balancer is used. Default is false (connect only to the leader).