### PR TITLE
Use dynamic batch publishing by default

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -470,7 +470,7 @@ blocking when the limit is reached.
 
 |`dynamicBatch`
 |Adapt batch size depending on ingress rate.
-|false
+|true
 
 |`confirmTimeout`
 |[[producer-confirm-timeout-configuration-entry]]Time before the client calls the confirm callback to signal
@@ -897,11 +897,11 @@ Useful when using an external store for offset tracking.
 |`flow#initialCredits`
 |Number of credits when the subscription is created.
 Increase for higher throughput at the expense of memory usage.
-|1
+|10
 
 |`flow#strategy`
 |The `ConsumerFlowStrategy` to use.
-|`ConsumerFlowStrategy#creditOnChunkArrival(1)`
+|`ConsumerFlowStrategy#creditOnChunkArrival(10)`
 |===
 
 [NOTE]

--- a/src/main/java/com/rabbitmq/stream/ConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/ConsumerBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -245,9 +245,13 @@ public interface ConsumerBuilder {
     /**
      * The number of initial credits for the subscription.
      *
-     * <p>Default is 1.
+     * <p>Default is 10.
      *
      * <p>This calls uses {@link ConsumerFlowStrategy#creditOnChunkArrival(int)}.
+     *
+     * <p>Use a small value like 1 for streams with large chunks (several hundreds of messages per
+     * chunk) and higher values (5 or more) for streams with small chunks (1 or a few messages per
+     * chunk).
      *
      * @param initialCredits the number of initial credits
      * @return this configuration instance

--- a/src/main/java/com/rabbitmq/stream/ConsumerFlowStrategy.java
+++ b/src/main/java/com/rabbitmq/stream/ConsumerFlowStrategy.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2023-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -120,13 +120,14 @@ public interface ConsumerFlowStrategy {
    *
    * @param initialCredits number of initial credits
    * @return flow strategy
+   * @see com.rabbitmq.stream.ConsumerBuilder.FlowConfiguration#initialCredits(int)
    */
   static ConsumerFlowStrategy creditOnChunkArrival(int initialCredits) {
     return new CreditOnChunkArrivalConsumerFlowStrategy(initialCredits);
   }
 
   /**
-   * Strategy that provides 1 initial credit and a credit when half of the chunk messages are
+   * Strategy that provides 10 initial credits and a credit when half of the chunk messages are
    * processed.
    *
    * <p>Make sure to call {@link MessageHandler.Context#processed()} on every message when using
@@ -135,7 +136,7 @@ public interface ConsumerFlowStrategy {
    * @return flow strategy
    */
   static ConsumerFlowStrategy creditWhenHalfMessagesProcessed() {
-    return creditOnProcessedMessageCount(1, 0.5);
+    return creditOnProcessedMessageCount(10, 0.5);
   }
 
   /**
@@ -147,6 +148,7 @@ public interface ConsumerFlowStrategy {
    *
    * @param initialCredits number of initial credits
    * @return flow strategy
+   * @see com.rabbitmq.stream.ConsumerBuilder.FlowConfiguration#initialCredits(int)
    */
   static ConsumerFlowStrategy creditWhenHalfMessagesProcessed(int initialCredits) {
     return creditOnProcessedMessageCount(initialCredits, 0.5);

--- a/src/main/java/com/rabbitmq/stream/ProducerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/ProducerBuilder.java
@@ -106,22 +106,26 @@ public interface ProducerBuilder {
   /**
    * Adapt batch size depending on ingress rate.
    *
-   * <p>A dynamic-batch approach improves latency for low ingress rates. It can be counterproductive
-   * for sustained high ingress rates.
+   * <p>A dynamic-batch approach improves latency for low ingress rates.
    *
    * <p>Set this flag to <code>true</code> if you want as little delay as possible between calling
    * {@link Producer#send(Message, ConfirmationHandler)} and the message being sent to the broker.
+   * Consumers should provide enough initial credits (between 5 and 10, depending on the workload),
+   * see {@link ConsumerBuilder#flow()} and {@link
+   * ConsumerBuilder.FlowConfiguration#initialCredits(int)}.
    *
    * <p>Set this flag to <code>false</code> if latency is not critical for your use case and you
-   * want the highest throughput possible for both publishing and consuming.
+   * want the highest throughput possible for both publishing and consuming. Consumers can provide 1
+   * initial credit (depending on the workload), see {@link ConsumerBuilder#flow()} and {@link
+   * ConsumerBuilder.FlowConfiguration#initialCredits(int)}.
    *
-   * <p>Dynamic batch is not activated by default (<code>dynamicBatch = false</code>).
-   *
-   * <p>Dynamic batch is experimental.
+   * <p>Dynamic batch is activated by default (<code>dynamicBatch = true</code>).
    *
    * @param dynamicBatch
    * @return this builder instance
    * @since 0.20.0
+   * @see ConsumerBuilder#flow()
+   * @see com.rabbitmq.stream.ConsumerBuilder.FlowConfiguration#initialCredits(int)
    */
   ProducerBuilder dynamicBatch(boolean dynamicBatch);
 

--- a/src/main/java/com/rabbitmq/stream/impl/StreamConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamConsumerBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -428,7 +428,7 @@ class StreamConsumerBuilder implements ConsumerBuilder {
       this.consumerBuilder = consumerBuilder;
     }
 
-    private ConsumerFlowStrategy strategy = ConsumerFlowStrategy.creditOnChunkArrival();
+    private ConsumerFlowStrategy strategy = ConsumerFlowStrategy.creditOnChunkArrival(10);
 
     @Override
     public FlowConfiguration initialCredits(int initialCredits) {

--- a/src/main/java/com/rabbitmq/stream/impl/StreamProducerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamProducerBuilder.java
@@ -29,7 +29,7 @@ import java.util.function.ToIntFunction;
 class StreamProducerBuilder implements ProducerBuilder {
 
   static final boolean DEFAULT_DYNAMIC_BATCH =
-      Boolean.parseBoolean(System.getProperty("rabbitmq.stream.producer.dynamic.batch", "false"));
+      Boolean.parseBoolean(System.getProperty("rabbitmq.stream.producer.dynamic.batch", "true"));
 
   private final StreamEnvironment environment;
 

--- a/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
@@ -665,7 +665,7 @@ public class ConsumersCoordinatorTest {
         new ConsumerFlowStrategy() {
           @Override
           public int initialCredits() {
-            return 1;
+            return 10;
           }
 
           @Override

--- a/src/test/java/com/rabbitmq/stream/impl/MessageCountConsumerFlowStrategyTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/MessageCountConsumerFlowStrategyTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Broadcom. All Rights Reserved.
+// Copyright (c) 2023-2024 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -55,7 +55,7 @@ public class MessageCountConsumerFlowStrategyTest {
   }
 
   ConsumerFlowStrategy build(double ratio) {
-    return creditOnProcessedMessageCount(1, ratio);
+    return creditOnProcessedMessageCount(10, ratio);
   }
 
   ConsumerFlowStrategy.Context context(long messageCount) {

--- a/src/test/java/com/rabbitmq/stream/impl/StreamConsumerTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamConsumerTest.java
@@ -203,7 +203,7 @@ public class StreamConsumerTest {
         environment.consumerBuilder().stream(stream)
             .offset(OffsetSpecification.first())
             .flow()
-            .strategy(creditWhenHalfMessagesProcessed())
+            .strategy(creditWhenHalfMessagesProcessed(1))
             .builder();
 
     List<MessageHandler.Context> messageContexts = synchronizedList(new ArrayList<>());
@@ -244,14 +244,13 @@ public class StreamConsumerTest {
     int messageCount = 100_000;
     publishAndWaitForConfirms(cf, messageCount, stream);
 
-    ExecutorService executorService =
-        Executors.newFixedThreadPool(getRuntime().availableProcessors());
-    try {
+    try (ExecutorService executorService =
+        Executors.newFixedThreadPool(getRuntime().availableProcessors())) {
       CountDownLatch latch = new CountDownLatch(messageCount);
       environment.consumerBuilder().stream(stream)
           .offset(OffsetSpecification.first())
           .flow()
-          .strategy(creditWhenHalfMessagesProcessed())
+          .strategy(creditWhenHalfMessagesProcessed(1))
           .builder()
           .messageHandler(
               (ctx, message) ->
@@ -262,8 +261,6 @@ public class StreamConsumerTest {
                       }))
           .build();
       assertThat(latch).is(completed());
-    } finally {
-      executorService.shutdownNow();
     }
   }
 

--- a/src/test/java/com/rabbitmq/stream/impl/StreamConsumerTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamConsumerTest.java
@@ -243,9 +243,9 @@ public class StreamConsumerTest {
   void asynchronousProcessingWithFlowControl() {
     int messageCount = 100_000;
     publishAndWaitForConfirms(cf, messageCount, stream);
-
-    try (ExecutorService executorService =
-        Executors.newFixedThreadPool(getRuntime().availableProcessors())) {
+    ExecutorService executorService =
+        Executors.newFixedThreadPool(getRuntime().availableProcessors());
+    try {
       CountDownLatch latch = new CountDownLatch(messageCount);
       environment.consumerBuilder().stream(stream)
           .offset(OffsetSpecification.first())
@@ -261,6 +261,8 @@ public class StreamConsumerTest {
                       }))
           .build();
       assertThat(latch).is(completed());
+    } finally {
+      executorService.shutdownNow();
     }
   }
 


### PR DESCRIPTION
And set initial credits to 10 by default, as dynamic batching creates smaller chunks for low ingress.