### PR TITLE
Consider max unconfirmed messages in dynamic batch configuration

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/DynamicBatchMessageAccumulator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/DynamicBatchMessageAccumulator.java
@@ -38,6 +38,7 @@ final class DynamicBatchMessageAccumulator implements MessageAccumulator {
   DynamicBatchMessageAccumulator(
       int subEntrySize,
       int batchSize,
+      int maxUnconfirmedMessages,
       Codec codec,
       int maxFrameSize,
       ToLongFunction<Message> publishSequenceFunction,
@@ -75,7 +76,8 @@ final class DynamicBatchMessageAccumulator implements MessageAccumulator {
                 }
                 return result;
               },
-              batchSize);
+              batchSize,
+              maxUnconfirmedMessages);
     } else {
       byte compressionCode =
           compressionCodec == null ? Compression.NONE.code() : compressionCodec.code();
@@ -124,7 +126,8 @@ final class DynamicBatchMessageAccumulator implements MessageAccumulator {
                 }
                 return result;
               },
-              batchSize * subEntrySize);
+              batchSize * subEntrySize,
+              maxUnconfirmedMessages);
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/ProducerUtils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ProducerUtils.java
@@ -30,6 +30,7 @@ final class ProducerUtils {
       boolean dynamicBatch,
       int subEntrySize,
       int batchSize,
+      int maxUnconfirmedMessages,
       CompressionCodec compressionCodec,
       Codec codec,
       ByteBufAllocator byteBufAllocator,
@@ -44,6 +45,7 @@ final class ProducerUtils {
       return new DynamicBatchMessageAccumulator(
           subEntrySize,
           batchSize,
+          maxUnconfirmedMessages,
           codec,
           maxFrameSize,
           publishSequenceFunction,

--- a/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
@@ -180,6 +180,7 @@ class StreamProducer implements Producer {
             dynamicBatch,
             subEntrySize,
             batchSize,
+            maxUnconfirmedMessages,
             compressionCodec,
             environment.codec(),
             environment.byteBufAllocator(),

--- a/src/test/java/com/rabbitmq/stream/impl/DynamicBatchTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/DynamicBatchTest.java
@@ -71,7 +71,7 @@ public class DynamicBatchTest {
           sync.down(items.size());
           return true;
         };
-    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100)) {
+    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100, 10_000)) {
       RateLimiter rateLimiter = RateLimiter.create(10000);
       IntStream.range(0, itemCount)
           .forEach(
@@ -102,7 +102,7 @@ public class DynamicBatchTest {
           }
           return result;
         };
-    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100)) {
+    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100, 10_000)) {
       int firstRoundCount = itemCount / 5;
       IntStream.range(0, firstRoundCount)
           .forEach(
@@ -132,7 +132,7 @@ public class DynamicBatchTest {
           return true;
         };
 
-    try (DynamicBatch<Long> batch = new DynamicBatch<>(action, batchSize)) {
+    try (DynamicBatch<Long> batch = new DynamicBatch<>(action, batchSize, 10_000)) {
       MetricRegistry metrics = new MetricRegistry();
       Meter rate = metrics.meter("publishing-rate");
       AtomicBoolean keepGoing = new AtomicBoolean(true);


### PR DESCRIPTION
A small value for max unconfirmed messages can impact the dynamic batch mechanism. This commit sets the min batch size to half the max unconfirmed messages value if it is less than the configured batch size.

References #757