### PR TITLE
Add Environment#storeOffset(String,String,long)

### DIFF
--- a/src/main/java/com/rabbitmq/stream/Environment.java
+++ b/src/main/java/com/rabbitmq/stream/Environment.java
@@ -84,6 +84,22 @@ public interface Environment extends AutoCloseable {
   StreamStats queryStreamStats(String stream);
 
   /**
+   * Store the offset for a given reference on the given stream.
+   *
+   * <p>This method is useful to store a given offset before a consumer is created.
+   *
+   * <p>Prefer the {@link Consumer#store(long)} or {@link MessageHandler.Context#storeOffset()}
+   * methods to store offsets while consuming messages.
+   *
+   * @see Consumer#store(long)
+   * @see MessageHandler.Context#storeOffset()
+   * @param reference the reference to store the offset for, e.g. a consumer name
+   * @param stream the stream
+   * @param offset the offset to store
+   */
+  void storeOffset(String reference, String stream, long offset);
+
+  /**
    * Return whether a stream exists or not.
    *
    * @param stream the stream to check the existence

--- a/src/main/java/com/rabbitmq/stream/impl/OffsetTrackingUtils.java
+++ b/src/main/java/com/rabbitmq/stream/impl/OffsetTrackingUtils.java
@@ -1,0 +1,125 @@
+// Copyright (c) 2025 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import static com.rabbitmq.stream.BackOffDelayPolicy.fixedWithInitialDelay;
+import static com.rabbitmq.stream.impl.AsyncRetry.asyncRetry;
+import static java.lang.String.format;
+import static java.time.Duration.ofMillis;
+
+import com.rabbitmq.stream.Constants;
+import com.rabbitmq.stream.NoOffsetException;
+import com.rabbitmq.stream.StreamException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class OffsetTrackingUtils {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OffsetTrackingUtils.class);
+
+  private OffsetTrackingUtils() {}
+
+  static long storedOffset(Supplier<Client> clientSupplier, String name, String stream) {
+    // the client can be null, so we catch any exception
+    Client.QueryOffsetResponse response;
+    try {
+      response = clientSupplier.get().queryOffset(name, stream);
+    } catch (Exception e) {
+      throw new IllegalStateException(
+          format(
+              "Not possible to query offset for name %s on stream %s for now: %s",
+              name, stream, e.getMessage()),
+          e);
+    }
+    if (response.isOk()) {
+      return response.getOffset();
+    } else if (response.getResponseCode() == Constants.RESPONSE_CODE_NO_OFFSET) {
+      throw new NoOffsetException(
+          format(
+              "No offset stored for name %s on stream %s (%s)",
+              name, stream, Utils.formatConstant(response.getResponseCode())));
+    } else {
+      throw new StreamException(
+          format(
+              "QueryOffset for name %s on stream %s returned an error (%s)",
+              name, stream, Utils.formatConstant(response.getResponseCode())),
+          response.getResponseCode());
+    }
+  }
+
+  static void waitForOffsetToBeStored(
+      String caller,
+      ScheduledExecutorService scheduledExecutorService,
+      LongSupplier offsetSupplier,
+      String name,
+      String stream,
+      long expectedStoredOffset) {
+    String reference = String.format("{stream=%s/name=%s}", stream, name);
+    CompletableFuture<Boolean> storedTask =
+        asyncRetry(
+                () -> {
+                  try {
+                    long lastStoredOffset = offsetSupplier.getAsLong();
+                    boolean stored = lastStoredOffset == expectedStoredOffset;
+                    LOGGER.debug(
+                        "Last stored offset from {} on {} is {}, expecting {}",
+                        caller,
+                        reference,
+                        lastStoredOffset,
+                        expectedStoredOffset);
+                    if (!stored) {
+                      throw new IllegalStateException();
+                    } else {
+                      return true;
+                    }
+                  } catch (StreamException e) {
+                    if (e.getCode() == Constants.RESPONSE_CODE_NO_OFFSET) {
+                      LOGGER.debug(
+                          "No stored offset for {} on {}, expecting {}",
+                          caller,
+                          reference,
+                          expectedStoredOffset);
+                      throw new IllegalStateException();
+                    } else {
+                      throw e;
+                    }
+                  }
+                })
+            .description(
+                "Last stored offset for %s on %s must be %d",
+                caller, reference, expectedStoredOffset)
+            .delayPolicy(fixedWithInitialDelay(ofMillis(200), ofMillis(200)))
+            .retry(exception -> exception instanceof IllegalStateException)
+            .scheduler(scheduledExecutorService)
+            .build();
+
+    try {
+      storedTask.get(10, TimeUnit.SECONDS);
+      LOGGER.debug("Offset {} stored ({}, {})", expectedStoredOffset, caller, reference);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    } catch (ExecutionException | TimeoutException e) {
+      LOGGER.warn("Error while checking offset has been stored", e);
+      storedTask.cancel(true);
+    }
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironment.java
@@ -557,6 +557,29 @@ class StreamEnvironment implements Environment {
   }
 
   @Override
+  public void storeOffset(String reference, String stream, long offset) {
+    checkNotClosed();
+    this.maybeInitializeLocator();
+    locatorOperation(
+        Utils.namedFunction(
+            l -> {
+              l.storeOffset(reference, stream, offset);
+              return null;
+            },
+            "Store offset %d for stream '%s' with reference '%s'",
+            offset,
+            stream,
+            reference));
+    OffsetTrackingUtils.waitForOffsetToBeStored(
+        "env-store-offset",
+        this.scheduledExecutorService,
+        () -> OffsetTrackingUtils.storedOffset(() -> locator().client(), reference, stream),
+        reference,
+        stream,
+        offset);
+  }
+
+  @Override
   public boolean streamExists(String stream) {
     checkNotClosed();
     this.maybeInitializeLocator();

--- a/src/test/java/com/rabbitmq/stream/impl/Assertions.java
+++ b/src/test/java/com/rabbitmq/stream/impl/Assertions.java
@@ -16,6 +16,7 @@ package com.rabbitmq.stream.impl;
 
 import static org.assertj.core.api.Assertions.fail;
 
+import com.rabbitmq.stream.Constants;
 import java.time.Duration;
 import org.assertj.core.api.AbstractObjectAssert;
 
@@ -23,8 +24,48 @@ final class Assertions {
 
   private Assertions() {}
 
+  static ResponseAssert assertThat(Client.Response response) {
+    return new ResponseAssert(response);
+  }
+
   static SyncAssert assertThat(TestUtils.Sync sync) {
     return new SyncAssert(sync);
+  }
+
+  static class ResponseAssert extends AbstractObjectAssert<ResponseAssert, Client.Response> {
+
+    public ResponseAssert(Client.Response response) {
+      super(response, ResponseAssert.class);
+    }
+
+    ResponseAssert isOk() {
+      if (!actual.isOk()) {
+        fail(
+            "Response should be successful but was not, response code is: %s",
+            Utils.formatConstant(actual.getResponseCode()));
+      }
+      return this;
+    }
+
+    ResponseAssert isNotOk() {
+      if (actual.isOk()) {
+        fail("Response should not be successful but was, response code is: %s", actual);
+      }
+      return this;
+    }
+
+    ResponseAssert hasCode(short responseCode) {
+      if (actual.getResponseCode() != responseCode) {
+        fail(
+            "Response code should be %s but was %s",
+            Utils.formatConstant(responseCode), Utils.formatConstant(actual.getResponseCode()));
+      }
+      return this;
+    }
+
+    ResponseAssert hasCodeNoOffset() {
+      return hasCode(Constants.RESPONSE_CODE_NO_OFFSET);
+    }
   }
 
   static class SyncAssert extends AbstractObjectAssert<SyncAssert, TestUtils.Sync> {

--- a/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamEnvironmentTest.java
@@ -14,6 +14,7 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
+import static com.rabbitmq.stream.impl.Assertions.assertThat;
 import static com.rabbitmq.stream.impl.TestUtils.*;
 import static com.rabbitmq.stream.impl.TestUtils.CountDownLatchConditions.completed;
 import static com.rabbitmq.stream.impl.TestUtils.ExceptionConditions.responseCode;
@@ -810,6 +811,21 @@ public class StreamEnvironmentTest {
     } finally {
       env.deleteStream(s);
       env.close();
+    }
+  }
+
+  @Test
+  void storeOffset() {
+    String ref = "app";
+    Client client = cf.get();
+    assertThat(client.queryOffset(ref, stream)).isNotOk().hasCodeNoOffset();
+    try (Environment env = environmentBuilder.build()) {
+      env.storeOffset(ref, stream, 42);
+      assertThat(client.queryOffset(ref, stream).getOffset()).isEqualTo(42);
+      env.storeOffset(ref, stream, 43);
+      assertThat(client.queryOffset(ref, stream).getOffset()).isEqualTo(43);
+      env.storeOffset(ref, stream, 0);
+      assertThat(client.queryOffset(ref, stream).getOffset()).isEqualTo(0);
     }
   }
 }


### PR DESCRIPTION
It stores the offset for a given reference on the given stream. The method is useful to store a given offset before a consumer is created.

References https://github.com/rabbitmq/rabbitmq-server/discussions/14124.