### PR TITLE
Switch to a maintained fork of lz4-java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
     <picocli.version>4.7.5</picocli.version>
     <commons-compress.version>1.28.0</commons-compress.version>
     <zstd-jni.version>1.5.7-6</zstd-jni.version>
-    <lz4-java.version>1.8.1</lz4-java.version>
+    <lz4-java.version>1.10.0</lz4-java.version>
     <snappy-java.version>1.1.10.8</snappy-java.version>
     <junit.jupiter.version>5.14.1</junit.jupiter.version>
     <assertj.version>3.27.6</assertj.version>
@@ -162,7 +162,7 @@
     </dependency>
 
     <dependency>
-      <groupId>org.lz4</groupId>
+      <groupId>at.yawk.lz4</groupId>
       <artifactId>lz4-java</artifactId>
       <version>${lz4-java.version}</version>
     </dependency>


### PR DESCRIPTION
We switch from [1] to [2]. [1]'s 1.8.1 release
was produced by the author of [2], plus
[2] is a drop-in replacement.

1. https://github.com/lz4/lz4-java
2. https://github.com/yawkat/lz4-java