### PR TITLE
Improve producer adaptative batching

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/DynamicBatch.java
+++ b/src/main/java/com/rabbitmq/stream/impl/DynamicBatch.java
@@ -30,21 +30,35 @@ final class DynamicBatch<T> implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DynamicBatch.class);
   private static final int MIN_BATCH_SIZE = 16;
 
-  private final BlockingQueue<T> requests = new LinkedBlockingQueue<>();
+  // Additive Increase, Multiplicative Decrease (AIMD) parameters
+  private static final double MULTIPLICATIVE_DECREASE_FACTOR = 0.5;
+  private static final int ADDITIVE_INCREASE_STEP_DIVISOR = 10; // configuredBatchSize / 10
+
+  private static final long RETRY_DELAY_MS = 50;
+
+  private final BlockingQueue<T> requests;
   private final BatchConsumer<T> consumer;
   private final int configuredBatchSize, minBatchSize, maxBatchSize;
+  private final int additiveIncreaseStep;
   private final Thread thread;
+  private volatile boolean running = true;
 
   DynamicBatch(BatchConsumer<T> consumer, int batchSize, int maxUnconfirmed, String id) {
     this.consumer = consumer;
+    this.requests = new LinkedBlockingQueue<>(max(1, maxUnconfirmed));
     if (batchSize < maxUnconfirmed) {
       this.minBatchSize = min(MIN_BATCH_SIZE, batchSize / 2);
     } else {
-      this.minBatchSize = min(1, maxUnconfirmed / 2);
+      this.minBatchSize = max(1, maxUnconfirmed / 2);
     }
     this.configuredBatchSize = batchSize;
     this.maxBatchSize = batchSize * 2;
+
+    // Calculate additive increase step: 10% of configured size, minimum 1
+    this.additiveIncreaseStep = max(1, batchSize / ADDITIVE_INCREASE_STEP_DIVISOR);
+
     this.thread = ThreadUtils.newInternalThread(id, this::loop);
+    this.thread.setDaemon(true);
     this.thread.start();
   }
 
@@ -52,17 +66,18 @@ final class DynamicBatch<T> implements AutoCloseable {
     try {
       requests.put(item);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new RuntimeException(e);
     }
   }
 
   private void loop() {
-    State<T> state = new State<>();
+    // Initial allocation based on maxBatchSize to avoid resizing if it grows
+    State<T> state = new State<>(new ArrayList<>(this.maxBatchSize));
     state.batchSize = this.configuredBatchSize;
-    state.items = new ArrayList<>(state.batchSize);
     Thread currentThread = Thread.currentThread();
     T item;
-    while (!currentThread.isInterrupted()) {
+    while (running && !currentThread.isInterrupted()) {
       try {
         item = this.requests.poll(100, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
@@ -71,59 +86,87 @@ final class DynamicBatch<T> implements AutoCloseable {
       }
       if (item != null) {
         state.items.add(item);
-        if (state.items.size() >= state.batchSize) {
-          this.maybeCompleteBatch(state, true);
-        } else {
-          pump(state, 2);
+        int remaining = state.batchSize - state.items.size();
+        if (remaining > 0) {
+          this.requests.drainTo(state.items, remaining);
         }
+        this.maybeCompleteBatch(state, state.items.size() >= state.batchSize);
       } else {
         this.maybeCompleteBatch(state, false);
       }
     }
   }
 
-  private void pump(State<T> state, int pumpCount) {
-    if (pumpCount <= 0) {
-      return;
-    }
-    T item = this.requests.poll();
-    if (item == null) {
-      this.maybeCompleteBatch(state, false);
-    } else {
-      state.items.add(item);
-      if (state.items.size() >= state.batchSize) {
-        this.maybeCompleteBatch(state, true);
-      }
-      this.pump(state, pumpCount - 1);
-    }
-  }
-
   private static final class State<T> {
 
     int batchSize;
-    List<T> items;
+    final ArrayList<T> items;
+
+    private State(ArrayList<T> items) {
+      this.items = items;
+    }
   }
 
   private void maybeCompleteBatch(State<T> state, boolean increaseIfCompleted) {
+    if (state.items.isEmpty()) {
+      return;
+    }
+
     try {
       boolean completed = this.consumer.process(state.items);
       if (completed) {
         if (increaseIfCompleted) {
-          state.batchSize = min(state.batchSize * 2, this.maxBatchSize);
+          // AIMD: Additive Increase
+          // Grow slowly and linearly when batch is full
+          state.batchSize = min(state.batchSize + this.additiveIncreaseStep, this.maxBatchSize);
         } else {
-          state.batchSize = max(state.batchSize / 2, this.minBatchSize);
+          // AIMD: Multiplicative Decrease
+          // React quickly to low utilization by cutting back
+          state.batchSize =
+              max((int) (state.batchSize * MULTIPLICATIVE_DECREASE_FACTOR), this.minBatchSize);
         }
-        state.items = new ArrayList<>(state.batchSize);
+        state.items.clear();
+        return;
       }
     } catch (Exception e) {
-      //      e.printStackTrace();
-      LOGGER.warn("Error during dynamic batch completion: {}", e.getMessage());
+      LOGGER.warn(
+          "Error during dynamic batch completion, batch size: {}, items: {}",
+          state.batchSize,
+          state.items.size(),
+          e);
+    }
+    try {
+      Thread.sleep(RETRY_DELAY_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 
   @Override
   public void close() {
+    this.running = false;
     this.thread.interrupt();
+    try {
+      this.thread.join(TimeUnit.SECONDS.toMillis(5));
+      if (this.thread.isAlive()) {
+        LOGGER.warn("Dynamic batch thread did not terminate within timeout");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn("Interrupted while waiting for dynamic batch thread to terminate");
+    }
+    // Process any remaining items in the queue
+    if (!this.requests.isEmpty()) {
+      List<T> remaining = new ArrayList<>();
+      this.requests.drainTo(remaining);
+      if (!remaining.isEmpty()) {
+        try {
+          this.consumer.process(remaining);
+        } catch (Exception e) {
+          LOGGER.warn("Error processing remaining {} items during shutdown", remaining.size(), e);
+        }
+      }
+    }
   }
 
   @FunctionalInterface

--- a/src/main/java/com/rabbitmq/stream/impl/StreamProducerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamProducerBuilder.java
@@ -112,6 +112,7 @@ class StreamProducerBuilder implements ProducerBuilder {
   }
 
   @Override
+  @SuppressWarnings("deprecation")
   public ProducerBuilder dynamicBatch(boolean dynamicBatch) {
     this.dynamicBatch = dynamicBatch;
     return this;

--- a/src/test/java/com/rabbitmq/stream/impl/DynamicBatchTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/DynamicBatchTest.java
@@ -17,6 +17,8 @@ package com.rabbitmq.stream.impl;
 import static com.rabbitmq.stream.impl.Assertions.assertThat;
 import static com.rabbitmq.stream.impl.TestUtils.sync;
 import static com.rabbitmq.stream.impl.TestUtils.waitAtMost;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -24,6 +26,9 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Snapshot;
 import com.google.common.util.concurrent.RateLimiter;
 import com.rabbitmq.stream.impl.TestUtils.Sync;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 import java.util.Random;
 import java.util.concurrent.Semaphore;
@@ -157,6 +162,219 @@ public class DynamicBatchTest {
           () ->
               System.nanoTime() - start > TimeUnit.SECONDS.toNanos(1) && rate.getMeanRate() > 1000);
     }
+  }
+
+  @Test
+  void addShouldThrowWhenInterrupted(TestInfo info) throws Exception {
+    DynamicBatch.BatchConsumer<String> action = items -> true;
+    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100, 10_000, batchId(info))) {
+      Thread testThread =
+          new Thread(
+              () -> {
+                Thread.currentThread().interrupt();
+                assertThatThrownBy(() -> batch.add("item"))
+                    .isInstanceOf(RuntimeException.class)
+                    .hasCauseInstanceOf(InterruptedException.class);
+              });
+      testThread.start();
+      testThread.join();
+    }
+  }
+
+  @Test
+  void batchSizeIncreasesWhenBatchIsFull(TestInfo info) throws Exception {
+    int batchSize = 100;
+    AtomicInteger maxObservedBatchSize = new AtomicInteger(0);
+    AtomicInteger totalProcessed = new AtomicInteger(0);
+    List<Integer> sizes = Collections.synchronizedList(new ArrayList<>());
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          maxObservedBatchSize.updateAndGet(v -> Math.max(v, items.size()));
+          totalProcessed.addAndGet(items.size());
+          sizes.add(items.size());
+          simulateActivity(5);
+          return true;
+        };
+
+    try (DynamicBatch<String> batch =
+        new DynamicBatch<>(action, batchSize, 10_000, batchId(info))) {
+      int itemCount = 5000;
+      IntStream.range(0, itemCount).parallel().forEach(i -> batch.add("item-" + i));
+      waitAtMost(() -> totalProcessed.get() == itemCount);
+
+      assertThat(maxObservedBatchSize.get()).isGreaterThan(batchSize);
+    }
+  }
+
+  @Test
+  void batchSizeDecreasesWhenBatchIsNotFull(TestInfo info) throws Exception {
+    int batchSize = 100;
+    List<Integer> observedBatchSizes = Collections.synchronizedList(new ArrayList<>());
+    AtomicInteger totalProcessed = new AtomicInteger(0);
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          observedBatchSizes.add(items.size());
+          totalProcessed.addAndGet(items.size());
+          simulateActivity(20);
+          return true;
+        };
+
+    try (DynamicBatch<String> batch =
+        new DynamicBatch<>(action, batchSize, 10_000, batchId(info))) {
+      int itemCount = 50;
+      IntStream.range(0, itemCount)
+          .forEach(
+              i -> {
+                batch.add("item-" + i);
+                simulateActivity(10);
+              });
+      waitAtMost(() -> totalProcessed.get() == itemCount);
+
+      assertThat(observedBatchSizes).anyMatch(s -> s < batchSize / 2);
+    }
+  }
+
+  @Test
+  void exceptionInProcessingIsHandledAndRetried(TestInfo info) throws Exception {
+    AtomicInteger attemptCount = new AtomicInteger(0);
+    AtomicInteger processedCount = new AtomicInteger(0);
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          int attempt = attemptCount.incrementAndGet();
+          if (attempt <= 2) {
+            throw new RuntimeException("Simulated failure");
+          }
+          processedCount.addAndGet(items.size());
+          return true;
+        };
+
+    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100, 10_000, batchId(info))) {
+      batch.add("item");
+      waitAtMost(() -> processedCount.get() == 1);
+      assertThat(attemptCount.get()).isGreaterThan(2);
+    }
+  }
+
+  @Test
+  void closeProcessesRemainingItems(TestInfo info) {
+    AtomicInteger processedCount = new AtomicInteger(0);
+    Semaphore blockProcessing = new Semaphore(0);
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          try {
+            blockProcessing.acquire(); // Block until released
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          processedCount.addAndGet(items.size());
+          return true;
+        };
+
+    DynamicBatch<String> batch = new DynamicBatch<>(action, 100, 10_000, batchId(info));
+
+    // Add items that will queue up
+    IntStream.range(0, 50).forEach(i -> batch.add("item-" + i));
+
+    // Release processing and close
+    blockProcessing.release(100);
+    batch.close();
+
+    // All items should be processed (including remaining in queue)
+    assertThat(processedCount.get()).isEqualTo(50);
+  }
+
+  @Test
+  void minBatchSizeCalculationWhenBatchSizeLessThanMaxUnconfirmed(TestInfo info) throws Exception {
+    int batchSize = 50;
+    int maxUnconfirmed = 10_000;
+    List<Integer> observedSizes = Collections.synchronizedList(new ArrayList<>());
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          observedSizes.add(items.size());
+          simulateActivity(10);
+          return true;
+        };
+
+    try (DynamicBatch<String> batch =
+        new DynamicBatch<>(action, batchSize, maxUnconfirmed, batchId(info))) {
+      IntStream.range(0, 20)
+          .forEach(
+              i -> {
+                batch.add("item-" + i);
+                simulateActivity(20);
+              });
+      waitAtMost(() -> observedSizes.stream().mapToInt(i -> i).sum() >= 20);
+
+      assertThat(observedSizes).anyMatch(s -> s <= 16);
+    }
+  }
+
+  @Test
+  void minBatchSizeCalculationWhenBatchSizeGreaterOrEqualMaxUnconfirmed(TestInfo info)
+      throws Exception {
+    int batchSize = 100;
+    int maxUnconfirmed = 50;
+    AtomicInteger processedCount = new AtomicInteger(0);
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          processedCount.addAndGet(items.size());
+          return true;
+        };
+
+    try (DynamicBatch<String> batch =
+        new DynamicBatch<>(action, batchSize, maxUnconfirmed, batchId(info))) {
+      IntStream.range(0, 100).forEach(i -> batch.add("item-" + i));
+      waitAtMost(() -> processedCount.get() == 100);
+    }
+
+    assertThat(processedCount.get()).isEqualTo(100);
+  }
+
+  @Test
+  void batchSizeDoesNotExceedMaxBatchSize(TestInfo info) throws Exception {
+    int batchSize = 100;
+    int maxBatchSize = batchSize * 2;
+    AtomicInteger maxObservedBatchSize = new AtomicInteger(0);
+    AtomicInteger totalProcessed = new AtomicInteger(0);
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          maxObservedBatchSize.updateAndGet(v -> Math.max(v, items.size()));
+          totalProcessed.addAndGet(items.size());
+          return true;
+        };
+
+    try (DynamicBatch<String> batch =
+        new DynamicBatch<>(action, batchSize, 10_000, batchId(info))) {
+      int itemCount = 50_000;
+      IntStream.range(0, itemCount).parallel().forEach(i -> batch.add("item-" + i));
+      waitAtMost(() -> totalProcessed.get() == itemCount);
+
+      assertThat(maxObservedBatchSize.get()).isLessThanOrEqualTo(maxBatchSize);
+    }
+  }
+
+  @Test
+  void emptyBatchIsNotProcessed(TestInfo info) throws Exception {
+    AtomicInteger processCallCount = new AtomicInteger(0);
+
+    DynamicBatch.BatchConsumer<String> action =
+        items -> {
+          processCallCount.incrementAndGet();
+          return true;
+        };
+
+    try (DynamicBatch<String> batch = new DynamicBatch<>(action, 100, 10_000, batchId(info))) {
+      Thread.sleep(300);
+    }
+
+    assertThat(processCallCount.get()).isZero();
   }
 
   private static String batchId(TestInfo info) {


### PR DESCRIPTION
* Use BlockingQueue#drain to dequeue items.
* Allocate loop list once and clear it after each batch instead of recreating it.
* Submit remaining items on closing.
* Use AIMD (Additive Increase, Multiplicative Decrease) to adapt batch size instead of dividing/multiplying by 2. This should reduce oscillation, have a more predictable behavior and converge to optimal utilization.
* Add new test cases.