### PR TITLE
Add internal AMQP message format codec

### DIFF
--- a/src/main/java/com/rabbitmq/stream/Codec.java
+++ b/src/main/java/com/rabbitmq/stream/Codec.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -14,7 +14,9 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.io.OutputStream;
 
 /**
  * Codec to encode and decode messages.
@@ -27,28 +29,16 @@ public interface Codec {
 
   EncodedMessage encode(Message message);
 
-  Message decode(byte[] data);
+  Message decode(ByteBuf buf, int length);
 
   MessageBuilder messageBuilder();
 
-  class EncodedMessage {
+  interface EncodedMessage {
 
-    private final int size;
-    private final byte[] data;
+    void writeTo(OutputStream outputStream) throws IOException;
 
-    @SuppressFBWarnings("EI_EXPOSE_REP2")
-    public EncodedMessage(int size, byte[] data) {
-      this.size = size;
-      this.data = data;
-    }
+    void writeTo(ByteBuf buf);
 
-    @SuppressFBWarnings("EI_EXPOSE_REP")
-    public byte[] getData() {
-      return data;
-    }
-
-    public int getSize() {
-      return size;
-    }
+    int getSize();
   }
 }

--- a/src/main/java/com/rabbitmq/stream/amqp/Symbol.java
+++ b/src/main/java/com/rabbitmq/stream/amqp/Symbol.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -14,9 +14,12 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.amqp;
 
-public class Symbol {
+import java.util.concurrent.ConcurrentHashMap;
 
-  // FIXME maintain a cache
+public final class Symbol {
+
+  private static final int CACHE_MAX_SIZE = 2048;
+  private static final ConcurrentHashMap<String, Symbol> CACHE = new ConcurrentHashMap<>(64);
 
   private final String value;
 
@@ -25,11 +28,40 @@ public class Symbol {
   }
 
   public static Symbol valueOf(String value) {
-    return new Symbol(value);
+    if (value == null) {
+      return null;
+    }
+    Symbol symbol = CACHE.get(value);
+    if (symbol == null) {
+      symbol = new Symbol(value);
+      if (CACHE.size() < CACHE_MAX_SIZE) {
+        Symbol existing = CACHE.putIfAbsent(value, symbol);
+        if (existing != null) {
+          symbol = existing;
+        }
+      }
+    }
+    return symbol;
   }
 
   @Override
   public String toString() {
     return value;
+  }
+
+  @Override
+  public int hashCode() {
+    return value.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    return value.equals(((Symbol) o).value);
   }
 }

--- a/src/main/java/com/rabbitmq/stream/codec/Amqp10.java
+++ b/src/main/java/com/rabbitmq/stream/codec/Amqp10.java
@@ -845,7 +845,7 @@ final class Amqp10 {
       case 9: // creation-time: timestamp
         return sizeOfTimestamp((Long) value);
       case 11: // group-sequence: sequence-no (uint)
-        return sizeOfUInt(((Long) value).intValue());
+        return sizeOfUInt(toUInt((Long) value));
       default:
         return sizeOfNull();
     }
@@ -1021,8 +1021,8 @@ final class Amqp10 {
       encodeMessageIdOrCorrelationId(props.getCorrelationId()), // 5: correlation-id
       props.getContentType(), // 6: content-type (symbol)
       props.getContentEncoding(), // 7: content-encoding (symbol)
-      props.getAbsoluteExpiryTime() > 0 ? props.getAbsoluteExpiryTime() : null, // 8
-      props.getCreationTime() > 0 ? props.getCreationTime() : null, // 9
+      props.getAbsoluteExpiryTime() != 0 ? props.getAbsoluteExpiryTime() : null, // 8
+      props.getCreationTime() != 0 ? props.getCreationTime() : null, // 9
       props.getGroupId(), // 10: group-id (string)
       props.getGroupSequence() >= 0 ? props.getGroupSequence() : null, // 11: group-sequence
       props.getReplyToGroupId() // 12: reply-to-group-id (string)
@@ -1036,6 +1036,14 @@ final class Amqp10 {
       }
     }
     return -1;
+  }
+
+  private static int toUInt(long value) {
+    if (value < 0 || value > 0xFFFFFFFFL) {
+      throw new IllegalArgumentException(
+          "Value " + value + " is outside the uint range [0, " + 0xFFFFFFFFL + "]");
+    }
+    return (int) value;
   }
 
   private static Object encodeMessageIdOrCorrelationId(Object id) {
@@ -1081,7 +1089,7 @@ final class Amqp10 {
         writeTimestamp(buf, (Long) value);
         break;
       case 11: // group-sequence: sequence-no (uint)
-        writeUInt(buf, ((Long) value).intValue());
+        writeUInt(buf, toUInt((Long) value));
         break;
       default:
         writeNull(buf);

--- a/src/main/java/com/rabbitmq/stream/codec/Amqp10.java
+++ b/src/main/java/com/rabbitmq/stream/codec/Amqp10.java
@@ -1,0 +1,1644 @@
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.codec;
+
+import com.rabbitmq.stream.Message;
+import com.rabbitmq.stream.Properties;
+import com.rabbitmq.stream.amqp.UnsignedByte;
+import com.rabbitmq.stream.amqp.UnsignedInteger;
+import com.rabbitmq.stream.amqp.UnsignedLong;
+import com.rabbitmq.stream.amqp.UnsignedShort;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufUtil;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Low-level AMQP 1.0 encoding and decoding utilities for RabbitMQ Stream messages.
+ *
+ * <p>This class provides the primitives to serialize and deserialize messages using the <a
+ * href="https://docs.oasis-open.org/amqp/core/v1.0/os/amqp-core-types-v1.0-os.html">AMQP 1.0 type
+ * system</a>. It supports the full range of AMQP 1.0 primitive types, composite types (lists, maps,
+ * arrays), and the message sections defined in the AMQP 1.0 message format (message annotations,
+ * properties, application properties, and body sections including data, amqp-value, and
+ * amqp-sequence).
+ *
+ * <p>Encoding is performed directly into Netty {@link ByteBuf} instances, using compact sub-type
+ * encodings where the specification allows (e.g. {@code smalluint}, {@code ulong0}). The class also
+ * provides size-calculation methods that mirror the encoding logic, enabling callers to pre-compute
+ * the exact encoded size of a message without materializing the bytes.
+ *
+ * <p><strong>This class is experimental and subject to change in future releases.</strong>
+ *
+ * @see InternalCodec
+ * @see StreamingEncodedMessage
+ */
+final class Amqp10 {
+
+  private static final byte[] EMPTY_BODY = new byte[0];
+
+  // AMQP 1.0 type format codes
+  static final byte DESCRIBED_TYPE_CONSTRUCTOR = 0x00;
+
+  static final byte NULL = 0x40;
+  static final byte BOOLEAN_TRUE = 0x41;
+  static final byte BOOLEAN_FALSE = 0x42;
+  static final byte BOOLEAN = 0x56;
+
+  static final byte UBYTE = 0x50;
+  static final byte BYTE = 0x51;
+  static final byte USHORT = 0x60;
+  static final byte SHORT = 0x61;
+
+  static final byte UINT = 0x70;
+  static final byte SMALLUINT = 0x52;
+  static final byte UINT0 = 0x43;
+  static final byte INT = 0x71;
+  static final byte SMALLINT = 0x54;
+
+  static final byte ULONG = (byte) 0x80;
+  static final byte SMALLULONG = 0x53;
+  static final byte ULONG0 = 0x44;
+  static final byte LONG = (byte) 0x81;
+  static final byte SMALLLONG = 0x55;
+
+  static final byte FLOAT = 0x72;
+  static final byte DOUBLE = (byte) 0x82;
+  static final byte CHAR = 0x73;
+  static final byte TIMESTAMP = (byte) 0x83;
+  static final byte UUID_TYPE = (byte) 0x98;
+
+  static final byte VBIN8 = (byte) 0xa0;
+  static final byte VBIN32 = (byte) 0xb0;
+  static final byte STR8 = (byte) 0xa1;
+  static final byte STR32 = (byte) 0xb1;
+  static final byte SYM8 = (byte) 0xa3;
+  static final byte SYM32 = (byte) 0xb3;
+
+  static final byte LIST0 = 0x45;
+  static final byte LIST8 = (byte) 0xc0;
+  static final byte LIST32 = (byte) 0xd0;
+  static final byte MAP8 = (byte) 0xc1;
+  static final byte MAP32 = (byte) 0xd1;
+  static final byte ARRAY8 = (byte) 0xe0;
+  static final byte ARRAY32 = (byte) 0xf0;
+
+  // Section descriptor codes (AMQP 1.0 message format)
+  static final long MESSAGE_ANNOTATIONS_DESCRIPTOR = 0x72L;
+  static final long PROPERTIES_DESCRIPTOR = 0x73L;
+  static final long APPLICATION_PROPERTIES_DESCRIPTOR = 0x74L;
+  static final long DATA_DESCRIPTOR = 0x75L;
+  static final long AMQP_SEQUENCE_DESCRIPTOR = 0x76L;
+  static final long AMQP_VALUE_DESCRIPTOR = 0x77L;
+
+  private Amqp10() {}
+
+  // --- Size Calculation: Primitives ---
+
+  static int sizeOfNull() {
+    return 1; // NULL
+  }
+
+  static int sizeOfBoolean(boolean value) {
+    return 1; // BOOLEAN_TRUE or BOOLEAN_FALSE
+  }
+
+  static int sizeOfUByte(byte value) {
+    return 2; // UBYTE + value
+  }
+
+  static int sizeOfByte(byte value) {
+    return 2; // BYTE + value
+  }
+
+  static int sizeOfUShort(short value) {
+    return 3; // USHORT + value
+  }
+
+  static int sizeOfShort(short value) {
+    return 3; // SHORT + value
+  }
+
+  static int sizeOfUInt(int value) {
+    if (value == 0) {
+      return 1; // UINT0
+    } else if ((value & 0xFF) == value) {
+      return 2; // SMALLUINT + value
+    } else {
+      return 5; // UINT + value
+    }
+  }
+
+  static int sizeOfInt(int value) {
+    if (value >= -128 && value <= 127) {
+      return 2; // SMALLINT + value
+    } else {
+      return 5; // INT + value
+    }
+  }
+
+  static int sizeOfULong(long value) {
+    if (value == 0) {
+      return 1; // ULONG0
+    } else if ((value & 0xFFL) == value) {
+      return 2; // SMALLULONG + value
+    } else {
+      return 9; // ULONG + value
+    }
+  }
+
+  static int sizeOfLong(long value) {
+    if (value >= -128 && value <= 127) {
+      return 2; // SMALLLONG + value
+    } else {
+      return 9; // LONG + value
+    }
+  }
+
+  static int sizeOfFloat(float value) {
+    return 5; // FLOAT + 4 bytes
+  }
+
+  static int sizeOfDouble(double value) {
+    return 9; // DOUBLE + 8 bytes
+  }
+
+  static int sizeOfChar(int codePoint) {
+    return 5; // CHAR + 4 bytes
+  }
+
+  static int sizeOfTimestamp(long millis) {
+    return 9; // TIMESTAMP + 8 bytes
+  }
+
+  static int sizeOfUuid(UUID uuid) {
+    return 17; // UUID_TYPE + 16 bytes
+  }
+
+  static int sizeOfBinary(byte[] data) {
+    if (data.length <= 255) {
+      return 2 + data.length; // VBIN8 + length + data
+    } else {
+      return 5 + data.length; // VBIN32 + length + data
+    }
+  }
+
+  static int sizeOfString(String value) {
+    int utf8Length = ByteBufUtil.utf8Bytes(value);
+    if (utf8Length <= 255) {
+      return 2 + utf8Length; // STR8 + length + data
+    } else {
+      return 5 + utf8Length; // STR32 + length + data
+    }
+  }
+
+  static int sizeOfSymbol(String value) {
+    int utf8Length = ByteBufUtil.utf8Bytes(value);
+    if (utf8Length <= 255) {
+      return 2 + utf8Length; // SYM8 + length + data
+    } else {
+      return 5 + utf8Length; // SYM32 + length + data
+    }
+  }
+
+  // --- Size Calculation: Composites ---
+
+  private static boolean fitsInCompact8(int elementSize, int count) {
+    return count <= 255 && elementSize + 1 <= 255;
+  }
+
+  private static boolean mapFitsInCompact8(int elementSize, int count) {
+    return count * 2 <= 255 && elementSize + 1 <= 255;
+  }
+
+  static int sizeOfList(List<?> list) {
+    if (list.isEmpty()) {
+      return 1; // LIST0
+    }
+    int elementSize = 0;
+    for (Object item : list) {
+      elementSize += sizeOfObject(item);
+    }
+    int count = list.size();
+    if (fitsInCompact8(elementSize, count)) {
+      return 1 + 1 + 1 + elementSize; // LIST8 + size + count + elements
+    }
+    return 1 + 4 + 4 + elementSize; // LIST32 + size + count + elements
+  }
+
+  static int sizeOfMap(Map<?, ?> map) {
+    int elementSize = 0;
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      elementSize += sizeOfObject(entry.getKey());
+      elementSize += sizeOfObject(entry.getValue());
+    }
+    int count = map.size();
+    if (mapFitsInCompact8(elementSize, count)) {
+      return 1 + 1 + 1 + elementSize; // MAP8 + size + count + elements
+    }
+    return 1 + 4 + 4 + elementSize; // MAP32 + size + count + elements
+  }
+
+  static int sizeOfSymbolKeyMap(Map<String, Object> map) {
+    int elementSize = 0;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      elementSize += sizeOfSymbol(entry.getKey());
+      elementSize += sizeOfObject(entry.getValue());
+    }
+    int count = map.size();
+    if (mapFitsInCompact8(elementSize, count)) {
+      return 1 + 1 + 1 + elementSize; // MAP8 + size + count + elements
+    }
+    return 1 + 4 + 4 + elementSize; // MAP32 + size + count + elements
+  }
+
+  static int sizeOfStringKeyMap(Map<String, Object> map) {
+    int elementSize = 0;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      elementSize += sizeOfString(entry.getKey());
+      elementSize += sizeOfObject(entry.getValue());
+    }
+    int count = map.size();
+    if (mapFitsInCompact8(elementSize, count)) {
+      return 1 + 1 + 1 + elementSize; // MAP8 + size + count + elements
+    }
+    return 1 + 4 + 4 + elementSize; // MAP32 + size + count + elements
+  }
+
+  static int sizeOfArray(Object[] array) {
+    if (array.length == 0) {
+      return 4; // ARRAY8 + size(1) + count(1) + type(NULL)
+    }
+    byte elementTypeCode = arrayTypeCodeFor(array[0]);
+    int elementSize = 0;
+    for (Object item : array) {
+      elementSize += sizeOfArrayElementValue(item, elementTypeCode);
+    }
+    int count = array.length;
+    // content inside the size field: count + type constructor + elements
+    int innerContent8 = 1 + 1 + elementSize; // count(1) + type(1) + elements
+    if (count <= 255 && innerContent8 <= 255) {
+      return 1 + 1 + innerContent8; // ARRAY8 + size + content
+    }
+    int innerContent32 = 4 + 1 + elementSize; // count(4) + type(1) + elements
+    return 1 + 4 + innerContent32; // ARRAY32 + size + content
+  }
+
+  private static int sizeOfArrayElementValue(Object value, byte elementTypeCode) {
+    switch (elementTypeCode) {
+      case BOOLEAN:
+        return 1; // single byte
+      case BYTE:
+        return 1;
+      case SHORT:
+        return 2;
+      case INT:
+        return 4;
+      case LONG:
+        return 8;
+      case FLOAT:
+        return 4;
+      case DOUBLE:
+        return 8;
+      case CHAR:
+        return 4;
+      case UUID_TYPE:
+        return 16;
+      case VBIN32:
+        byte[] data = (byte[]) value;
+        return 4 + data.length;
+      case STR32:
+        String str = (String) value;
+        return 4 + ByteBufUtil.utf8Bytes(str);
+      case SYM32:
+        String symbol = value.toString();
+        return 4 + ByteBufUtil.utf8Bytes(symbol);
+      case UBYTE:
+        return 1;
+      case USHORT:
+        return 2;
+      case UINT:
+        return 4;
+      case ULONG:
+        return 8;
+      default:
+        throw new IllegalArgumentException(
+            "Array element type not supported: 0x" + Integer.toHexString(elementTypeCode & 0xFF));
+    }
+  }
+
+  // --- Encoding: Primitives ---
+
+  static void writeNull(ByteBuf buf) {
+    buf.writeByte(NULL);
+  }
+
+  static void writeBoolean(ByteBuf buf, boolean value) {
+    buf.writeByte(value ? BOOLEAN_TRUE : BOOLEAN_FALSE);
+  }
+
+  static void writeUByte(ByteBuf buf, byte value) {
+    buf.writeByte(UBYTE);
+    buf.writeByte(value);
+  }
+
+  static void writeByte(ByteBuf buf, byte value) {
+    buf.writeByte(BYTE);
+    buf.writeByte(value);
+  }
+
+  static void writeUShort(ByteBuf buf, short value) {
+    buf.writeByte(USHORT);
+    buf.writeShort(value);
+  }
+
+  static void writeShort(ByteBuf buf, short value) {
+    buf.writeByte(SHORT);
+    buf.writeShort(value);
+  }
+
+  static void writeUInt(ByteBuf buf, int value) {
+    // Note: When UnsignedInteger > Integer.MAX_VALUE is converted to int, it becomes negative.
+    // The logic below works correctly for negative ints because:
+    // - value == 0 check fails (negative != 0)
+    // - (value & 0xFF) == value check fails for all negative values
+    // - Falls through to UINT encoding which handles the full 32-bit range
+    if (value == 0) {
+      buf.writeByte(UINT0);
+    } else if ((value & 0xFF) == value) {
+      buf.writeByte(SMALLUINT);
+      buf.writeByte(value);
+    } else {
+      buf.writeByte(UINT);
+      buf.writeInt(value);
+    }
+  }
+
+  static void writeInt(ByteBuf buf, int value) {
+    if (value >= -128 && value <= 127) {
+      buf.writeByte(SMALLINT);
+      buf.writeByte(value);
+    } else {
+      buf.writeByte(INT);
+      buf.writeInt(value);
+    }
+  }
+
+  static void writeULong(ByteBuf buf, long value) {
+    if (value == 0) {
+      buf.writeByte(ULONG0);
+    } else if ((value & 0xFFL) == value) {
+      buf.writeByte(SMALLULONG);
+      buf.writeByte((int) value);
+    } else {
+      buf.writeByte(ULONG);
+      buf.writeLong(value);
+    }
+  }
+
+  static void writeLong(ByteBuf buf, long value) {
+    if (value >= -128 && value <= 127) {
+      buf.writeByte(SMALLLONG);
+      buf.writeByte((int) value);
+    } else {
+      buf.writeByte(LONG);
+      buf.writeLong(value);
+    }
+  }
+
+  static void writeFloat(ByteBuf buf, float value) {
+    buf.writeByte(FLOAT);
+    buf.writeInt(Float.floatToRawIntBits(value));
+  }
+
+  static void writeDouble(ByteBuf buf, double value) {
+    buf.writeByte(DOUBLE);
+    buf.writeLong(Double.doubleToRawLongBits(value));
+  }
+
+  static void writeChar(ByteBuf buf, int codePoint) {
+    buf.writeByte(CHAR);
+    buf.writeInt(codePoint);
+  }
+
+  static void writeTimestamp(ByteBuf buf, long millis) {
+    buf.writeByte(TIMESTAMP);
+    buf.writeLong(millis);
+  }
+
+  static void writeUuid(ByteBuf buf, UUID uuid) {
+    buf.writeByte(UUID_TYPE);
+    buf.writeLong(uuid.getMostSignificantBits());
+    buf.writeLong(uuid.getLeastSignificantBits());
+  }
+
+  static void writeBinary(ByteBuf buf, byte[] data) {
+    if (data.length <= 255) {
+      buf.writeByte(VBIN8);
+      buf.writeByte(data.length);
+    } else {
+      buf.writeByte(VBIN32);
+      buf.writeInt(data.length);
+    }
+    buf.writeBytes(data);
+  }
+
+  static void writeString(ByteBuf buf, String value) {
+    int length = ByteBufUtil.utf8Bytes(value);
+    if (length <= 255) {
+      buf.writeByte(STR8);
+      buf.writeByte(length);
+    } else {
+      buf.writeByte(STR32);
+      buf.writeInt(length);
+    }
+    buf.writeCharSequence(value, StandardCharsets.UTF_8);
+  }
+
+  static void writeSymbol(ByteBuf buf, String value) {
+    int length = ByteBufUtil.utf8Bytes(value);
+    if (length <= 255) {
+      buf.writeByte(SYM8);
+      buf.writeByte(length);
+    } else {
+      buf.writeByte(SYM32);
+      buf.writeInt(length);
+    }
+    buf.writeCharSequence(value, StandardCharsets.US_ASCII);
+  }
+
+  // --- Encoding: Composites ---
+
+  static void writeList(ByteBuf buf, List<?> list) {
+    if (list.isEmpty()) {
+      buf.writeByte(LIST0);
+      return;
+    }
+    int elementSize = 0;
+    for (Object item : list) {
+      elementSize += sizeOfObject(item);
+    }
+    int count = list.size();
+    if (fitsInCompact8(elementSize, count)) {
+      buf.writeByte(LIST8);
+      buf.writeByte(elementSize + 1); // size = count(1) + elements
+      buf.writeByte(count);
+    } else {
+      buf.writeByte(LIST32);
+      buf.writeInt(elementSize + 4); // size = count(4) + elements
+      buf.writeInt(count);
+    }
+    for (Object item : list) {
+      writeObject(buf, item);
+    }
+  }
+
+  static void writeMap(ByteBuf buf, Map<?, ?> map) {
+    int elementSize = 0;
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      elementSize += sizeOfObject(entry.getKey());
+      elementSize += sizeOfObject(entry.getValue());
+    }
+    int count = map.size();
+    if (mapFitsInCompact8(elementSize, count)) {
+      buf.writeByte(MAP8);
+      buf.writeByte(elementSize + 1); // size = count(1) + elements
+      buf.writeByte(count * 2);
+    } else {
+      buf.writeByte(MAP32);
+      buf.writeInt(elementSize + 4); // size = count(4) + elements
+      buf.writeInt(count * 2);
+    }
+    for (Map.Entry<?, ?> entry : map.entrySet()) {
+      writeObject(buf, entry.getKey());
+      writeObject(buf, entry.getValue());
+    }
+  }
+
+  static void writeSymbolKeyMap(ByteBuf buf, Map<String, Object> map) {
+    int elementSize = 0;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      elementSize += sizeOfSymbol(entry.getKey());
+      elementSize += sizeOfObject(entry.getValue());
+    }
+    int count = map.size();
+    if (mapFitsInCompact8(elementSize, count)) {
+      buf.writeByte(MAP8);
+      buf.writeByte(elementSize + 1); // size = count(1) + elements
+      buf.writeByte(count * 2);
+    } else {
+      buf.writeByte(MAP32);
+      buf.writeInt(elementSize + 4); // size = count(4) + elements
+      buf.writeInt(count * 2);
+    }
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      writeSymbol(buf, entry.getKey());
+      writeObject(buf, entry.getValue());
+    }
+  }
+
+  static void writeStringKeyMap(ByteBuf buf, Map<String, Object> map) {
+    int elementSize = 0;
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      elementSize += sizeOfString(entry.getKey());
+      elementSize += sizeOfObject(entry.getValue());
+    }
+    int count = map.size();
+    if (mapFitsInCompact8(elementSize, count)) {
+      buf.writeByte(MAP8);
+      buf.writeByte(elementSize + 1); // size = count(1) + elements
+      buf.writeByte(count * 2);
+    } else {
+      buf.writeByte(MAP32);
+      buf.writeInt(elementSize + 4); // size = count(4) + elements
+      buf.writeInt(count * 2);
+    }
+    for (Map.Entry<String, Object> entry : map.entrySet()) {
+      writeString(buf, entry.getKey());
+      writeObject(buf, entry.getValue());
+    }
+  }
+
+  static void writeArray(ByteBuf buf, Object[] array) {
+    if (array.length == 0) {
+      buf.writeByte(ARRAY8);
+      buf.writeByte(2); // size = 1 (count) + 1 (type code)
+      buf.writeByte(0); // count
+      buf.writeByte(NULL);
+      return;
+    }
+    byte elementTypeCode = arrayTypeCodeFor(array[0]);
+    int elementSize = 0;
+    for (Object item : array) {
+      elementSize += sizeOfArrayElementValue(item, elementTypeCode);
+    }
+    int count = array.length;
+    int innerContent8 = 1 + 1 + elementSize; // count(1) + type(1) + elements
+    if (count <= 255 && innerContent8 <= 255) {
+      buf.writeByte(ARRAY8);
+      buf.writeByte(innerContent8);
+      buf.writeByte(count);
+    } else {
+      buf.writeByte(ARRAY32);
+      int innerContent32 = 4 + 1 + elementSize; // count(4) + type(1) + elements
+      buf.writeInt(innerContent32);
+      buf.writeInt(count);
+    }
+    buf.writeByte(elementTypeCode);
+    for (Object item : array) {
+      writeArrayElementValue(buf, item, elementTypeCode);
+    }
+  }
+
+  /**
+   * Returns the AMQP type code for the array element constructor. Always returns the widest
+   * encoding for variable-width and compact types so that all elements use a uniform
+   * representation.
+   */
+  private static byte arrayTypeCodeFor(Object value) {
+    if (value instanceof Boolean) {
+      return BOOLEAN;
+    } else if (value instanceof Byte) {
+      return BYTE;
+    } else if (value instanceof Short) {
+      return SHORT;
+    } else if (value instanceof Integer) {
+      return INT;
+    } else if (value instanceof Long) {
+      return LONG;
+    } else if (value instanceof Float) {
+      return FLOAT;
+    } else if (value instanceof Double) {
+      return DOUBLE;
+    } else if (value instanceof Character) {
+      return CHAR;
+    } else if (value instanceof UUID) {
+      return UUID_TYPE;
+    } else if (value instanceof byte[]) {
+      return VBIN32;
+    } else if (value instanceof String) {
+      return STR32;
+    } else if (value instanceof com.rabbitmq.stream.amqp.Symbol) {
+      return SYM32;
+    } else if (value instanceof UnsignedByte) {
+      return UBYTE;
+    } else if (value instanceof UnsignedShort) {
+      return USHORT;
+    } else if (value instanceof UnsignedInteger) {
+      return UINT;
+    } else if (value instanceof UnsignedLong) {
+      return ULONG;
+    } else {
+      throw new IllegalArgumentException(
+          "Array element type not supported: " + value.getClass().getName());
+    }
+  }
+
+  /**
+   * Writes the value bytes for an element inside an array, strictly formatted according to the
+   * given element type code (no type code prefix).
+   */
+  private static void writeArrayElementValue(ByteBuf buf, Object value, byte elementTypeCode) {
+    switch (elementTypeCode) {
+      case BOOLEAN:
+        buf.writeByte(((Boolean) value) ? 1 : 0);
+        break;
+      case BYTE:
+        buf.writeByte((Byte) value);
+        break;
+      case SHORT:
+        buf.writeShort((Short) value);
+        break;
+      case INT:
+        buf.writeInt((Integer) value);
+        break;
+      case LONG:
+        buf.writeLong((Long) value);
+        break;
+      case FLOAT:
+        buf.writeInt(Float.floatToRawIntBits((Float) value));
+        break;
+      case DOUBLE:
+        buf.writeLong(Double.doubleToRawLongBits((Double) value));
+        break;
+      case CHAR:
+        buf.writeInt((Character) value);
+        break;
+      case UUID_TYPE:
+        {
+          UUID uuid = (UUID) value;
+          buf.writeLong(uuid.getMostSignificantBits());
+          buf.writeLong(uuid.getLeastSignificantBits());
+        }
+        break;
+      case VBIN32:
+        {
+          byte[] data = (byte[]) value;
+          buf.writeInt(data.length);
+          buf.writeBytes(data);
+        }
+        break;
+      case STR32:
+        {
+          String str = (String) value;
+          int length = ByteBufUtil.utf8Bytes(str);
+          buf.writeInt(length);
+          buf.writeCharSequence(str, StandardCharsets.UTF_8);
+        }
+        break;
+      case SYM32:
+        {
+          String symbol = value.toString();
+          int length = ByteBufUtil.utf8Bytes(symbol);
+          buf.writeInt(length);
+          buf.writeCharSequence(symbol, StandardCharsets.US_ASCII);
+        }
+        break;
+      case UBYTE:
+        buf.writeByte(((UnsignedByte) value).byteValue());
+        break;
+      case USHORT:
+        buf.writeShort(((UnsignedShort) value).shortValue());
+        break;
+      case UINT:
+        buf.writeInt(((UnsignedInteger) value).intValue());
+        break;
+      case ULONG:
+        buf.writeLong(((UnsignedLong) value).longValue());
+        break;
+      default:
+        throw new IllegalArgumentException(
+            "Array element type not supported: 0x" + Integer.toHexString(elementTypeCode & 0xFF));
+    }
+  }
+
+  // --- Size Calculation: Object dispatch ---
+
+  static int sizeOfObject(Object value) {
+    if (value == null) {
+      return sizeOfNull();
+    } else if (value instanceof Boolean) {
+      return sizeOfBoolean((Boolean) value);
+    } else if (value instanceof Byte) {
+      return sizeOfByte((Byte) value);
+    } else if (value instanceof Short) {
+      return sizeOfShort((Short) value);
+    } else if (value instanceof Integer) {
+      return sizeOfInt((Integer) value);
+    } else if (value instanceof Long) {
+      return sizeOfLong((Long) value);
+    } else if (value instanceof UnsignedByte) {
+      return sizeOfUByte(((UnsignedByte) value).byteValue());
+    } else if (value instanceof UnsignedShort) {
+      return sizeOfUShort(((UnsignedShort) value).shortValue());
+    } else if (value instanceof UnsignedInteger) {
+      return sizeOfUInt(((UnsignedInteger) value).intValue());
+    } else if (value instanceof UnsignedLong) {
+      return sizeOfULong(((UnsignedLong) value).longValue());
+    } else if (value instanceof Float) {
+      return sizeOfFloat((Float) value);
+    } else if (value instanceof Double) {
+      return sizeOfDouble((Double) value);
+    } else if (value instanceof Character) {
+      return sizeOfChar((Character) value);
+    } else if (value instanceof Date) {
+      return sizeOfTimestamp(((Date) value).getTime());
+    } else if (value instanceof UUID) {
+      return sizeOfUuid((UUID) value);
+    } else if (value instanceof byte[]) {
+      return sizeOfBinary((byte[]) value);
+    } else if (value instanceof String) {
+      return sizeOfString((String) value);
+    } else if (value instanceof com.rabbitmq.stream.amqp.Symbol) {
+      return sizeOfSymbol(value.toString());
+    } else if (value instanceof List) {
+      return sizeOfList((List<?>) value);
+    } else if (value instanceof Map) {
+      return sizeOfMap((Map<?, ?>) value);
+    } else if (value instanceof Object[]) {
+      return sizeOfArray((Object[]) value);
+    } else {
+      throw new IllegalArgumentException("Type not supported: " + value.getClass().getName());
+    }
+  }
+
+  // --- Size Calculation: Described types (sections) ---
+
+  static int sizeOfDescriptor(long descriptorCode) {
+    return 1 + sizeOfULong(descriptorCode); // DESCRIBED_TYPE_CONSTRUCTOR + descriptor
+  }
+
+  // --- Size Calculation: Message sections ---
+
+  static int sizeOfMessageAnnotations(Map<String, Object> annotations) {
+    return sizeOfDescriptor(MESSAGE_ANNOTATIONS_DESCRIPTOR) + sizeOfSymbolKeyMap(annotations);
+  }
+
+  static int sizeOfApplicationProperties(Map<String, Object> appProperties) {
+    return sizeOfDescriptor(APPLICATION_PROPERTIES_DESCRIPTOR) + sizeOfStringKeyMap(appProperties);
+  }
+
+  static int sizeOfData(byte[] data) {
+    return sizeOfDescriptor(DATA_DESCRIPTOR) + sizeOfBinary(data);
+  }
+
+  static int sizeOfProperties(Properties props) {
+    int descriptorSize = sizeOfDescriptor(PROPERTIES_DESCRIPTOR);
+
+    Object[] fields = buildPropertyFields(props);
+
+    int lastNonNull = lastNonNullIndex(fields);
+
+    if (lastNonNull == -1) {
+      return descriptorSize + 1; // LIST0
+    }
+
+    int count = lastNonNull + 1;
+    int elementSize = 0;
+    for (int i = 0; i < count; i++) {
+      elementSize += sizeOfPropertyField(i, fields[i]);
+    }
+
+    if (fitsInCompact8(elementSize, count)) {
+      return descriptorSize + 1 + 1 + 1 + elementSize; // LIST8 + size + count + elements
+    }
+    return descriptorSize + 1 + 4 + 4 + elementSize; // LIST32 + size + count + elements
+  }
+
+  private static int sizeOfPropertyField(int index, Object value) {
+    if (value == null) {
+      return sizeOfNull();
+    }
+    switch (index) {
+      case 0: // message-id: can be ulong, uuid, binary, or string
+      case 5: // correlation-id: same types
+        return sizeOfIdField(value);
+      case 1: // user-id: binary
+        return sizeOfBinary((byte[]) value);
+      case 2: // to: string
+      case 3: // subject: string
+      case 4: // reply-to: string
+      case 10: // group-id: string
+      case 12: // reply-to-group-id: string
+        return sizeOfString((String) value);
+      case 6: // content-type: symbol
+      case 7: // content-encoding: symbol
+        return sizeOfSymbol((String) value);
+      case 8: // absolute-expiry-time: timestamp
+      case 9: // creation-time: timestamp
+        return sizeOfTimestamp((Long) value);
+      case 11: // group-sequence: sequence-no (uint)
+        return sizeOfUInt(((Long) value).intValue());
+      default:
+        return sizeOfNull();
+    }
+  }
+
+  private static int sizeOfIdField(Object id) {
+    if (id instanceof Long) {
+      return sizeOfULong((Long) id);
+    } else if (id instanceof String) {
+      return sizeOfString((String) id);
+    } else if (id instanceof byte[]) {
+      return sizeOfBinary((byte[]) id);
+    } else if (id instanceof UUID) {
+      return sizeOfUuid((UUID) id);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported message-id/correlation-id type: " + id.getClass().getName());
+    }
+  }
+
+  // --- Message Size Calculation ---
+
+  static int calculateMessageSize(Message message) {
+    int size = 0;
+
+    if (message.getMessageAnnotations() != null && !message.getMessageAnnotations().isEmpty()) {
+      size += sizeOfMessageAnnotations(message.getMessageAnnotations());
+    }
+
+    if (message.getProperties() != null) {
+      size += sizeOfProperties(message.getProperties());
+    }
+
+    if (message.getApplicationProperties() != null
+        && !message.getApplicationProperties().isEmpty()) {
+      size += sizeOfApplicationProperties(message.getApplicationProperties());
+    }
+
+    // Body size calculation - mirrors InternalCodec.encode logic exactly
+    byte[] bodyBinary = null;
+    try {
+      bodyBinary = message.getBodyAsBinary();
+    } catch (IllegalStateException e) {
+      // non-binary body (e.g. AmqpValue with a String), handled below
+    }
+
+    if (bodyBinary != null) {
+      size += sizeOfData(bodyBinary);
+    } else {
+      Object body = message.getBody();
+      if (body != null) {
+        size += sizeOfDescriptor(AMQP_VALUE_DESCRIPTOR) + sizeOfObject(body);
+      } else {
+        size += sizeOfData(EMPTY_BODY);
+      }
+    }
+
+    return size;
+  }
+
+  // --- Encoding: Object dispatch ---
+
+  static void writeObject(ByteBuf buf, Object value) {
+    if (value == null) {
+      writeNull(buf);
+    } else if (value instanceof Boolean) {
+      writeBoolean(buf, (Boolean) value);
+    } else if (value instanceof Byte) {
+      writeByte(buf, (Byte) value);
+    } else if (value instanceof Short) {
+      writeShort(buf, (Short) value);
+    } else if (value instanceof Integer) {
+      writeInt(buf, (Integer) value);
+    } else if (value instanceof Long) {
+      writeLong(buf, (Long) value);
+    } else if (value instanceof UnsignedByte) {
+      writeUByte(buf, ((UnsignedByte) value).byteValue());
+    } else if (value instanceof UnsignedShort) {
+      writeUShort(buf, ((UnsignedShort) value).shortValue());
+    } else if (value instanceof UnsignedInteger) {
+      writeUInt(buf, ((UnsignedInteger) value).intValue());
+    } else if (value instanceof UnsignedLong) {
+      writeULong(buf, ((UnsignedLong) value).longValue());
+    } else if (value instanceof Float) {
+      writeFloat(buf, (Float) value);
+    } else if (value instanceof Double) {
+      writeDouble(buf, (Double) value);
+    } else if (value instanceof Character) {
+      writeChar(buf, (Character) value);
+    } else if (value instanceof Date) {
+      writeTimestamp(buf, ((Date) value).getTime());
+    } else if (value instanceof UUID) {
+      writeUuid(buf, (UUID) value);
+    } else if (value instanceof byte[]) {
+      writeBinary(buf, (byte[]) value);
+    } else if (value instanceof String) {
+      writeString(buf, (String) value);
+    } else if (value instanceof com.rabbitmq.stream.amqp.Symbol) {
+      writeSymbol(buf, value.toString());
+    } else if (value instanceof List) {
+      writeList(buf, (List<?>) value);
+    } else if (value instanceof Map) {
+      writeMap(buf, (Map<?, ?>) value);
+    } else if (value instanceof Object[]) {
+      writeArray(buf, (Object[]) value);
+    } else {
+      throw new IllegalArgumentException("Type not supported: " + value.getClass().getName());
+    }
+  }
+
+  // --- Encoding: Described types (sections) ---
+
+  static void writeDescriptor(ByteBuf buf, long descriptorCode) {
+    buf.writeByte(DESCRIBED_TYPE_CONSTRUCTOR);
+    writeULong(buf, descriptorCode);
+  }
+
+  // --- Encoding: Message sections ---
+
+  static void writeMessageAnnotations(ByteBuf buf, Map<String, Object> annotations) {
+    writeDescriptor(buf, MESSAGE_ANNOTATIONS_DESCRIPTOR);
+    writeSymbolKeyMap(buf, annotations);
+  }
+
+  static void writeApplicationProperties(ByteBuf buf, Map<String, Object> appProperties) {
+    writeDescriptor(buf, APPLICATION_PROPERTIES_DESCRIPTOR);
+    writeStringKeyMap(buf, appProperties);
+  }
+
+  static void writeData(ByteBuf buf, byte[] data) {
+    writeDescriptor(buf, DATA_DESCRIPTOR);
+    writeBinary(buf, data);
+  }
+
+  static void writeProperties(ByteBuf buf, Properties props) {
+    writeDescriptor(buf, PROPERTIES_DESCRIPTOR);
+    Object[] fields = buildPropertyFields(props);
+
+    int lastNonNull = lastNonNullIndex(fields);
+
+    if (lastNonNull == -1) {
+      buf.writeByte(LIST0);
+      return;
+    }
+
+    int count = lastNonNull + 1;
+    int elementSize = 0;
+    for (int i = 0; i < count; i++) {
+      elementSize += sizeOfPropertyField(i, fields[i]);
+    }
+
+    if (fitsInCompact8(elementSize, count)) {
+      buf.writeByte(LIST8);
+      buf.writeByte(elementSize + 1); // size = count(1) + elements
+      buf.writeByte(count);
+    } else {
+      buf.writeByte(LIST32);
+      buf.writeInt(elementSize + 4); // size = count(4) + elements
+      buf.writeInt(count);
+    }
+    for (int i = 0; i < count; i++) {
+      writePropertyField(buf, i, fields[i]);
+    }
+  }
+
+  private static Object[] buildPropertyFields(Properties props) {
+    return new Object[] {
+      encodeMessageIdOrCorrelationId(props.getMessageId()), // 0: message-id
+      props.getUserId(), // 1: user-id (binary)
+      props.getTo(), // 2: to (string)
+      props.getSubject(), // 3: subject (string)
+      props.getReplyTo(), // 4: reply-to (string)
+      encodeMessageIdOrCorrelationId(props.getCorrelationId()), // 5: correlation-id
+      props.getContentType(), // 6: content-type (symbol)
+      props.getContentEncoding(), // 7: content-encoding (symbol)
+      props.getAbsoluteExpiryTime() > 0 ? props.getAbsoluteExpiryTime() : null, // 8
+      props.getCreationTime() > 0 ? props.getCreationTime() : null, // 9
+      props.getGroupId(), // 10: group-id (string)
+      props.getGroupSequence() >= 0 ? props.getGroupSequence() : null, // 11: group-sequence
+      props.getReplyToGroupId() // 12: reply-to-group-id (string)
+    };
+  }
+
+  private static int lastNonNullIndex(Object[] fields) {
+    for (int i = fields.length - 1; i >= 0; i--) {
+      if (fields[i] != null) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  private static Object encodeMessageIdOrCorrelationId(Object id) {
+    if (id == null) {
+      return null;
+    }
+    if (id instanceof Long || id instanceof String || id instanceof byte[] || id instanceof UUID) {
+      return id;
+    }
+    // External codec types (QPid, SwiftMQ) may wrap IDs in their own Number/binary types
+    if (id instanceof Number) {
+      return ((Number) id).longValue();
+    }
+    return id;
+  }
+
+  private static void writePropertyField(ByteBuf buf, int index, Object value) {
+    if (value == null) {
+      writeNull(buf);
+      return;
+    }
+    switch (index) {
+      case 0: // message-id: can be ulong, uuid, binary, or string
+      case 5: // correlation-id: same types
+        writeIdField(buf, value);
+        break;
+      case 1: // user-id: binary
+        writeBinary(buf, (byte[]) value);
+        break;
+      case 2: // to: string
+      case 3: // subject: string
+      case 4: // reply-to: string
+      case 10: // group-id: string
+      case 12: // reply-to-group-id: string
+        writeString(buf, (String) value);
+        break;
+      case 6: // content-type: symbol
+      case 7: // content-encoding: symbol
+        writeSymbol(buf, (String) value);
+        break;
+      case 8: // absolute-expiry-time: timestamp
+      case 9: // creation-time: timestamp
+        writeTimestamp(buf, (Long) value);
+        break;
+      case 11: // group-sequence: sequence-no (uint)
+        writeUInt(buf, ((Long) value).intValue());
+        break;
+      default:
+        writeNull(buf);
+    }
+  }
+
+  private static void writeIdField(ByteBuf buf, Object id) {
+    if (id instanceof Long) {
+      writeULong(buf, (Long) id);
+    } else if (id instanceof String) {
+      writeString(buf, (String) id);
+    } else if (id instanceof byte[]) {
+      writeBinary(buf, (byte[]) id);
+    } else if (id instanceof UUID) {
+      writeUuid(buf, (UUID) id);
+    } else {
+      throw new IllegalArgumentException(
+          "Unsupported message-id/correlation-id type: " + id.getClass().getName());
+    }
+  }
+
+  // --- Decoding ---
+
+  static Object readObject(ByteBuf buf) {
+    byte code = buf.readByte();
+    return readObjectWithCode(buf, code);
+  }
+
+  @SuppressWarnings("fallthrough")
+  private static Object readObjectWithCode(ByteBuf buf, byte code) {
+    switch (code) {
+      case NULL:
+        return null;
+      case BOOLEAN_TRUE:
+        return Boolean.TRUE;
+      case BOOLEAN_FALSE:
+        return Boolean.FALSE;
+      case BOOLEAN:
+        return buf.readByte() != 0 ? Boolean.TRUE : Boolean.FALSE;
+      case UBYTE:
+        return UnsignedByte.valueOf(buf.readByte());
+      case BYTE:
+        return buf.readByte();
+      case USHORT:
+        return UnsignedShort.valueOf(buf.readShort());
+      case SHORT:
+        return buf.readShort();
+      case UINT:
+        return UnsignedInteger.valueOf(buf.readInt());
+      case SMALLUINT:
+        return UnsignedInteger.valueOf(buf.readByte() & 0xFF);
+      case UINT0:
+        return UnsignedInteger.valueOf(0);
+      case INT:
+        return buf.readInt();
+      case SMALLINT:
+        return (int) buf.readByte();
+      case ULONG:
+        return UnsignedLong.valueOf(buf.readLong());
+      case SMALLULONG:
+        return UnsignedLong.valueOf(buf.readByte() & 0xFFL);
+      case ULONG0:
+        return UnsignedLong.valueOf(0);
+      case LONG:
+        return buf.readLong();
+      case SMALLLONG:
+        return (long) buf.readByte();
+      case FLOAT:
+        return Float.intBitsToFloat(buf.readInt());
+      case DOUBLE:
+        return Double.longBitsToDouble(buf.readLong());
+      case CHAR:
+        return buf.readInt();
+      case TIMESTAMP:
+        // Returns raw milliseconds as Long, not Date object.
+        // This causes type fidelity loss during Date roundtrip encoding/decoding.
+        // Consistent with QPid Proton behavior but should be documented.
+        return buf.readLong();
+      case UUID_TYPE:
+        return new UUID(buf.readLong(), buf.readLong());
+      case VBIN8:
+        {
+          int len = buf.readByte() & 0xFF;
+          byte[] data = new byte[len];
+          buf.readBytes(data);
+          return data;
+        }
+      case VBIN32:
+        {
+          int len = buf.readInt();
+          byte[] data = new byte[len];
+          buf.readBytes(data);
+          return data;
+        }
+      case STR8:
+        {
+          int len = buf.readByte() & 0xFF;
+          String result = buf.toString(buf.readerIndex(), len, StandardCharsets.UTF_8);
+          buf.skipBytes(len);
+          return result;
+        }
+      case STR32:
+        {
+          int len = buf.readInt();
+          String result = buf.toString(buf.readerIndex(), len, StandardCharsets.UTF_8);
+          buf.skipBytes(len);
+          return result;
+        }
+      case SYM8:
+        {
+          int len = buf.readByte() & 0xFF;
+          String result = buf.toString(buf.readerIndex(), len, StandardCharsets.US_ASCII);
+          buf.skipBytes(len);
+          return result;
+        }
+      case SYM32:
+        {
+          int len = buf.readInt();
+          String result = buf.toString(buf.readerIndex(), len, StandardCharsets.US_ASCII);
+          buf.skipBytes(len);
+          return result;
+        }
+      case LIST0:
+        return new ArrayList<>(0);
+      case LIST8:
+        return readList8(buf);
+      case LIST32:
+        return readList32(buf);
+      case MAP8:
+        return readMap8(buf);
+      case MAP32:
+        return readMap32(buf);
+      case ARRAY8:
+        return readArray8(buf);
+      case ARRAY32:
+        return readArray32(buf);
+      case DESCRIBED_TYPE_CONSTRUCTOR:
+        return readDescribedType(buf);
+      default:
+        throw new IllegalArgumentException(
+            "Unknown AMQP type code: 0x" + Integer.toHexString(code & 0xFF));
+    }
+  }
+
+  private static List<Object> readList8(ByteBuf buf) {
+    buf.readByte(); // size
+    int count = buf.readByte() & 0xFF;
+    return readListElements(buf, count);
+  }
+
+  private static List<Object> readList32(ByteBuf buf) {
+    buf.readInt(); // size (skip, we use count)
+    int count = buf.readInt();
+    return readListElements(buf, count);
+  }
+
+  private static List<Object> readListElements(ByteBuf buf, int count) {
+    List<Object> list = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      list.add(readObject(buf));
+    }
+    return list;
+  }
+
+  private static Map<Object, Object> readMap8(ByteBuf buf) {
+    buf.readByte(); // size
+    int count = buf.readByte() & 0xFF;
+    return readMapEntries(buf, count / 2);
+  }
+
+  private static Map<Object, Object> readMap32(ByteBuf buf) {
+    buf.readInt(); // size
+    int count = buf.readInt();
+    return readMapEntries(buf, count / 2);
+  }
+
+  private static Map<Object, Object> readMapEntries(ByteBuf buf, int entryCount) {
+    Map<Object, Object> map = new LinkedHashMap<>(entryCount);
+    for (int i = 0; i < entryCount; i++) {
+      Object key = readObject(buf);
+      Object value = readObject(buf);
+      map.put(key, value);
+    }
+    return map;
+  }
+
+  private static Object readArray8(ByteBuf buf) {
+    buf.readByte(); // size
+    int count = buf.readByte() & 0xFF;
+    return readArrayElements(buf, count);
+  }
+
+  private static Object readArray32(ByteBuf buf) {
+    buf.readInt(); // size
+    int count = buf.readInt();
+    return readArrayElements(buf, count);
+  }
+
+  private static Object readArrayElements(ByteBuf buf, int count) {
+    if (count == 0) {
+      buf.readByte(); // skip element type constructor
+      return new Object[0];
+    }
+    byte elementType = buf.readByte();
+    switch (elementType) {
+      case BYTE:
+        {
+          byte[] arr = new byte[count];
+          buf.readBytes(arr);
+          return arr;
+        }
+      case INT:
+        {
+          int[] arr = new int[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readInt();
+          return arr;
+        }
+      case SMALLINT:
+        {
+          int[] arr = new int[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readByte();
+          return arr;
+        }
+      case LONG:
+        {
+          long[] arr = new long[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readLong();
+          return arr;
+        }
+      case SMALLLONG:
+        {
+          long[] arr = new long[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readByte();
+          return arr;
+        }
+      case FLOAT:
+        {
+          float[] arr = new float[count];
+          for (int i = 0; i < count; i++) arr[i] = Float.intBitsToFloat(buf.readInt());
+          return arr;
+        }
+      case DOUBLE:
+        {
+          double[] arr = new double[count];
+          for (int i = 0; i < count; i++) arr[i] = Double.longBitsToDouble(buf.readLong());
+          return arr;
+        }
+      case BOOLEAN:
+        {
+          boolean[] arr = new boolean[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readByte() != 0;
+          return arr;
+        }
+      case UBYTE:
+        {
+          byte[] arr = new byte[count];
+          buf.readBytes(arr);
+          return arr;
+        }
+      case USHORT:
+        {
+          short[] arr = new short[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readShort();
+          return arr;
+        }
+      case SHORT:
+        {
+          short[] arr = new short[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readShort();
+          return arr;
+        }
+      case UINT:
+        {
+          int[] arr = new int[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readInt();
+          return arr;
+        }
+      case SMALLUINT:
+        {
+          int[] arr = new int[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readByte() & 0xFF;
+          return arr;
+        }
+      case ULONG:
+        {
+          long[] arr = new long[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readLong();
+          return arr;
+        }
+      case SMALLULONG:
+        {
+          long[] arr = new long[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readByte() & 0xFFL;
+          return arr;
+        }
+      case CHAR:
+        {
+          int[] arr = new int[count];
+          for (int i = 0; i < count; i++) arr[i] = buf.readInt();
+          return arr;
+        }
+      default:
+        {
+          Object[] result = new Object[count];
+          for (int i = 0; i < count; i++) {
+            result[i] = readObjectWithCode(buf, elementType);
+          }
+          return result;
+        }
+    }
+  }
+
+  // --- Decoding: Described types ---
+
+  private static Object readDescribedType(ByteBuf buf) {
+    // The constructor byte (0x00) has already been consumed
+    Object descriptor = readObject(buf);
+    Object value = readObject(buf);
+    return new DescribedValue(descriptor, value);
+  }
+
+  /** Internal holder for described types encountered during decoding. */
+  static final class DescribedValue {
+    final Object descriptor;
+    final Object value;
+
+    DescribedValue(Object descriptor, Object value) {
+      this.descriptor = descriptor;
+      this.value = value;
+    }
+
+    long descriptorCode() {
+      if (descriptor instanceof UnsignedLong) {
+        return ((UnsignedLong) descriptor).longValue();
+      }
+      return -1;
+    }
+  }
+
+  // --- Decoding: Message sections ---
+
+  @SuppressWarnings("unchecked")
+  static DecodedMessage decodeMessage(ByteBuf buf, int length) {
+    int endIndex = buf.readerIndex() + length;
+
+    Map<String, Object> messageAnnotations = null;
+    Properties properties = null;
+    Map<String, Object> applicationProperties = null;
+    byte[] bodyData = null;
+    Object body = null;
+
+    while (buf.readerIndex() < endIndex) {
+      Object section = readObject(buf);
+      if (!(section instanceof DescribedValue)) {
+        continue;
+      }
+      DescribedValue dv = (DescribedValue) section;
+      long code = dv.descriptorCode();
+      if (code == MESSAGE_ANNOTATIONS_DESCRIPTOR) {
+        messageAnnotations = toStringKeyMap((Map<Object, Object>) dv.value);
+      } else if (code == PROPERTIES_DESCRIPTOR) {
+        properties = decodeProperties((List<Object>) dv.value);
+      } else if (code == APPLICATION_PROPERTIES_DESCRIPTOR) {
+        applicationProperties = toStringKeyMap((Map<Object, Object>) dv.value);
+      } else if (code == DATA_DESCRIPTOR) {
+        bodyData = (byte[]) dv.value;
+        body = bodyData;
+      } else if (code == AMQP_SEQUENCE_DESCRIPTOR) {
+        if (body == null) {
+          body = dv.value;
+        }
+      } else if (code == AMQP_VALUE_DESCRIPTOR) {
+        body = dv.value;
+        if (dv.value instanceof byte[]) {
+          bodyData = (byte[]) dv.value;
+        }
+      }
+    }
+
+    return new DecodedMessage(
+        messageAnnotations, properties, applicationProperties, bodyData, body);
+  }
+
+  private static Map<String, Object> toStringKeyMap(Map<Object, Object> source) {
+    if (source == null) {
+      return null;
+    }
+    Map<String, Object> result = new LinkedHashMap<>(source.size());
+    for (Map.Entry<Object, Object> entry : source.entrySet()) {
+      result.put(entry.getKey().toString(), entry.getValue());
+    }
+    return result;
+  }
+
+  private static Properties decodeProperties(List<Object> fields) {
+    if (fields == null) {
+      return null;
+    }
+    return new DecodedProperties(fields);
+  }
+
+  static final class DecodedMessage {
+    final Map<String, Object> messageAnnotations;
+    final Properties properties;
+    final Map<String, Object> applicationProperties;
+    final byte[] bodyData;
+    final Object body;
+
+    DecodedMessage(
+        Map<String, Object> messageAnnotations,
+        Properties properties,
+        Map<String, Object> applicationProperties,
+        byte[] bodyData,
+        Object body) {
+      this.messageAnnotations = messageAnnotations;
+      this.properties = properties;
+      this.applicationProperties = applicationProperties;
+      this.bodyData = bodyData;
+      this.body = body;
+    }
+  }
+
+  static final class DecodedProperties implements Properties {
+    private static final long NULL_GROUP_SEQUENCE = -1L;
+    private static final long NULL_TIMESTAMP = 0L;
+    private final List<Object> fields;
+
+    DecodedProperties(List<Object> fields) {
+      this.fields = fields;
+    }
+
+    private Object field(int index) {
+      return index < fields.size() ? fields.get(index) : null;
+    }
+
+    @Override
+    public Object getMessageId() {
+      return field(0);
+    }
+
+    @Override
+    public String getMessageIdAsString() {
+      Object id = field(0);
+      return id == null ? null : id.toString();
+    }
+
+    @Override
+    public long getMessageIdAsLong() {
+      Object id = field(0);
+      if (id instanceof UnsignedLong) {
+        return ((UnsignedLong) id).longValue();
+      }
+      return ((Number) id).longValue();
+    }
+
+    @Override
+    public byte[] getMessageIdAsBinary() {
+      return (byte[]) field(0);
+    }
+
+    @Override
+    public UUID getMessageIdAsUuid() {
+      return (UUID) field(0);
+    }
+
+    @Override
+    public byte[] getUserId() {
+      return (byte[]) field(1);
+    }
+
+    @Override
+    public String getTo() {
+      return (String) field(2);
+    }
+
+    @Override
+    public String getSubject() {
+      return (String) field(3);
+    }
+
+    @Override
+    public String getReplyTo() {
+      return (String) field(4);
+    }
+
+    @Override
+    public Object getCorrelationId() {
+      return field(5);
+    }
+
+    @Override
+    public String getCorrelationIdAsString() {
+      Object id = field(5);
+      return id == null ? null : id.toString();
+    }
+
+    @Override
+    public long getCorrelationIdAsLong() {
+      Object id = field(5);
+      if (id instanceof UnsignedLong) {
+        return ((UnsignedLong) id).longValue();
+      }
+      return ((Number) id).longValue();
+    }
+
+    @Override
+    public byte[] getCorrelationIdAsBinary() {
+      return (byte[]) field(5);
+    }
+
+    @Override
+    public UUID getCorrelationIdAsUuid() {
+      return (UUID) field(5);
+    }
+
+    @Override
+    public String getContentType() {
+      return (String) field(6);
+    }
+
+    @Override
+    public String getContentEncoding() {
+      return (String) field(7);
+    }
+
+    @Override
+    public long getAbsoluteExpiryTime() {
+      Object v = field(8);
+      return v == null ? NULL_TIMESTAMP : ((Number) v).longValue();
+    }
+
+    @Override
+    public long getCreationTime() {
+      Object v = field(9);
+      return v == null ? NULL_TIMESTAMP : ((Number) v).longValue();
+    }
+
+    @Override
+    public String getGroupId() {
+      return (String) field(10);
+    }
+
+    @Override
+    public long getGroupSequence() {
+      Object v = field(11);
+      if (v == null) {
+        return NULL_GROUP_SEQUENCE;
+      }
+      if (v instanceof UnsignedInteger) {
+        return ((UnsignedInteger) v).longValue();
+      }
+      return ((Number) v).longValue();
+    }
+
+    @Override
+    public String getReplyToGroupId() {
+      return (String) field(12);
+    }
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/codec/ByteArrayEncodedMessage.java
+++ b/src/main/java/com/rabbitmq/stream/codec/ByteArrayEncodedMessage.java
@@ -1,0 +1,52 @@
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.codec;
+
+import com.rabbitmq.stream.Codec;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.buffer.ByteBuf;
+import java.io.IOException;
+import java.io.OutputStream;
+
+public class ByteArrayEncodedMessage implements Codec.EncodedMessage {
+
+  private final int size;
+  private final byte[] data;
+
+  @SuppressFBWarnings("EI_EXPOSE_REP2")
+  public ByteArrayEncodedMessage(int size, byte[] data) {
+    this.size = size;
+    this.data = data;
+  }
+
+  @Override
+  public void writeTo(OutputStream outputStream) throws IOException {
+    outputStream.write((this.size >>> 24) & 0xFF);
+    outputStream.write((this.size >>> 16) & 0xFF);
+    outputStream.write((this.size >>> 8) & 0xFF);
+    outputStream.write((this.size >>> 0) & 0xFF);
+    outputStream.write(this.data, 0, this.size);
+  }
+
+  @Override
+  public void writeTo(ByteBuf buf) {
+    buf.writeInt(this.size).writeBytes(this.data, 0, this.size);
+  }
+
+  @Override
+  public int getSize() {
+    return size;
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/codec/ByteArrayEncodedMessage.java
+++ b/src/main/java/com/rabbitmq/stream/codec/ByteArrayEncodedMessage.java
@@ -20,7 +20,7 @@ import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.io.OutputStream;
 
-public class ByteArrayEncodedMessage implements Codec.EncodedMessage {
+public final class ByteArrayEncodedMessage implements Codec.EncodedMessage {
 
   private final int size;
   private final byte[] data;

--- a/src/main/java/com/rabbitmq/stream/codec/InternalCodec.java
+++ b/src/main/java/com/rabbitmq/stream/codec/InternalCodec.java
@@ -1,0 +1,163 @@
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.codec;
+
+import com.rabbitmq.stream.Codec;
+import com.rabbitmq.stream.Message;
+import com.rabbitmq.stream.MessageBuilder;
+import com.rabbitmq.stream.Properties;
+import io.netty.buffer.ByteBuf;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Zero-dependency {@link Codec} implementation that encodes and decodes messages in AMQP 1.0 format
+ * using the library's own {@link Amqp10} primitives, with no external AMQP library (e.g. QPid
+ * Proton) required.
+ *
+ * <h3>Encoding</h3>
+ *
+ * <p>{@link #encode(Message)} returns a {@link StreamingEncodedMessage} that defers AMQP 1.0
+ * serialization until write time. The encoded size is pre-computed eagerly so the caller can
+ * allocate buffers of the right capacity, but no intermediate byte array is created. Encoding
+ * writes the following sections in order when present: message annotations (symbol-keyed map),
+ * properties (AMQP 1.0 properties list), application properties (string-keyed map), and body. The
+ * body is encoded as an AMQP {@code data} section if {@link Message#getBodyAsBinary()} succeeds, as
+ * an {@code amqp-value} section for non-binary bodies (e.g. a String), or as an empty {@code data}
+ * section when the body is {@code null}.
+ *
+ * <h3>Decoding</h3>
+ *
+ * <p>{@link #decode(ByteBuf, int)} reads AMQP 1.0 described types from the given buffer region and
+ * reconstructs an immutable {@code Message}. Decoded properties are backed by a positional {@code
+ * List} (not a POJO), avoiding field-by-field allocation. Map sections (message annotations,
+ * application properties) preserve insertion order via {@link LinkedHashMap}. AMQP {@code
+ * timestamp} values are returned as raw {@code long} milliseconds, not {@link java.util.Date}
+ * objects—this matches QPid Proton behavior but means a {@code Date} set on a property will round-
+ * trip as a {@code Long}.
+ *
+ * @see Amqp10
+ * @see StreamingEncodedMessage
+ */
+public class InternalCodec implements Codec {
+
+  @Override
+  public EncodedMessage encode(Message message) {
+    return new StreamingEncodedMessage(message);
+  }
+
+  @Override
+  public Message decode(ByteBuf buf, int length) {
+    Amqp10.DecodedMessage decoded = Amqp10.decodeMessage(buf, length);
+    return new InternalMessage(
+        decoded.properties,
+        decoded.applicationProperties,
+        decoded.messageAnnotations,
+        decoded.bodyData,
+        decoded.body);
+  }
+
+  @Override
+  public MessageBuilder messageBuilder() {
+    return new WrapperMessageBuilder();
+  }
+
+  private static final class InternalMessage implements Message {
+
+    private final Properties properties;
+    private final Map<String, Object> applicationProperties;
+    private Map<String, Object> messageAnnotations;
+    private final byte[] bodyData;
+    private final Object body;
+
+    InternalMessage(
+        Properties properties,
+        Map<String, Object> applicationProperties,
+        Map<String, Object> messageAnnotations,
+        byte[] bodyData,
+        Object body) {
+      this.properties = properties;
+      this.applicationProperties = applicationProperties;
+      this.messageAnnotations = messageAnnotations;
+      this.bodyData = bodyData;
+      this.body = body;
+    }
+
+    @Override
+    public boolean hasPublishingId() {
+      return false;
+    }
+
+    @Override
+    public long getPublishingId() {
+      return 0;
+    }
+
+    @Override
+    public byte[] getBodyAsBinary() {
+      if (bodyData != null) {
+        return bodyData;
+      }
+      if (body == null) {
+        return null;
+      }
+      if (body instanceof byte[]) {
+        return (byte[]) body;
+      }
+      throw new IllegalStateException(
+          "Body cannot be returned as array of bytes. Use #getBody() to get native representation.");
+    }
+
+    @Override
+    public Object getBody() {
+      return body;
+    }
+
+    @Override
+    public Properties getProperties() {
+      return properties;
+    }
+
+    @Override
+    public Map<String, Object> getApplicationProperties() {
+      return applicationProperties;
+    }
+
+    @Override
+    public Map<String, Object> getMessageAnnotations() {
+      if (messageAnnotations == null) {
+        messageAnnotations = new LinkedHashMap<>();
+      }
+      return messageAnnotations;
+    }
+
+    @Override
+    public Message annotate(String key, Object value) {
+      if (messageAnnotations == null) {
+        messageAnnotations = new LinkedHashMap<>();
+      }
+      messageAnnotations.put(key, value);
+      return this;
+    }
+
+    @Override
+    public Message copy() {
+      Map<String, Object> annotationsCopy =
+          this.messageAnnotations == null ? null : new LinkedHashMap<>(this.messageAnnotations);
+      return new InternalMessage(
+          this.properties, this.applicationProperties, annotationsCopy, this.bodyData, this.body);
+    }
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/codec/QpidProtonCodec.java
+++ b/src/main/java/com/rabbitmq/stream/codec/QpidProtonCodec.java
@@ -197,12 +197,12 @@ public class QpidProtonCodec implements Codec {
           propertiesSet = true;
         }
 
-        if (headers.getAbsoluteExpiryTime() > 0) {
+        if (headers.getAbsoluteExpiryTime() != 0) {
           properties.setAbsoluteExpiryTime(new Date(headers.getAbsoluteExpiryTime()));
           propertiesSet = true;
         }
 
-        if (headers.getCreationTime() > 0) {
+        if (headers.getCreationTime() != 0) {
           properties.setCreationTime(new Date(headers.getCreationTime()));
           propertiesSet = true;
         }

--- a/src/main/java/com/rabbitmq/stream/codec/QpidProtonCodec.java
+++ b/src/main/java/com/rabbitmq/stream/codec/QpidProtonCodec.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -18,6 +18,7 @@ import com.rabbitmq.stream.Codec;
 import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageBuilder;
 import com.rabbitmq.stream.Properties;
+import io.netty.buffer.ByteBuf;
 import java.nio.ByteBuffer;
 import java.util.Date;
 import java.util.LinkedHashMap;
@@ -261,14 +262,23 @@ public class QpidProtonCodec implements Codec {
     }
     ByteArrayWritableBuffer writableBuffer = new ByteArrayWritableBuffer(bufferSize);
     qpidMessage.encode(writableBuffer);
-    return new EncodedMessage(writableBuffer.getArrayLength(), writableBuffer.getArray());
+    return new ByteArrayEncodedMessage(writableBuffer.getArrayLength(), writableBuffer.getArray());
   }
 
   @Override
-  public Message decode(byte[] data) {
+  public Message decode(ByteBuf buf, int length) {
     org.apache.qpid.proton.message.Message message =
         org.apache.qpid.proton.message.Message.Factory.create();
-    message.decode(data, 0, data.length);
+    if (buf.nioBufferCount() > 0) {
+      ReadableBuffer readableBuffer =
+          ReadableBuffer.ByteBufferReader.wrap(buf.nioBuffer(buf.readerIndex(), length));
+      message.decode(readableBuffer);
+      buf.skipBytes(length);
+    } else {
+      byte[] data = new byte[length];
+      buf.readBytes(data);
+      message.decode(data, 0, length);
+    }
     return new QpidProtonMessage(
         message,
         createProperties(message),

--- a/src/main/java/com/rabbitmq/stream/codec/QpidProtonMessageBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/codec/QpidProtonMessageBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -127,7 +127,7 @@ class QpidProtonMessageBuilder implements MessageBuilder {
 
     @Override
     public PropertiesBuilder messageId(long id) {
-      properties.setMessageId(new UnsignedLong(id));
+      properties.setMessageId(UnsignedLong.valueOf(id));
       return this;
     }
 
@@ -175,7 +175,7 @@ class QpidProtonMessageBuilder implements MessageBuilder {
 
     @Override
     public PropertiesBuilder correlationId(long correlationId) {
-      properties.setCorrelationId(new UnsignedLong(correlationId));
+      properties.setCorrelationId(UnsignedLong.valueOf(correlationId));
       return this;
     }
 
@@ -281,25 +281,25 @@ class QpidProtonMessageBuilder implements MessageBuilder {
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, byte value) {
-      messageAnnotations.put(Symbol.getSymbol(key), new UnsignedByte(value));
+      messageAnnotations.put(Symbol.getSymbol(key), UnsignedByte.valueOf(value));
       return this;
     }
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, short value) {
-      messageAnnotations.put(Symbol.getSymbol(key), new UnsignedShort(value));
+      messageAnnotations.put(Symbol.getSymbol(key), UnsignedShort.valueOf(value));
       return this;
     }
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, int value) {
-      messageAnnotations.put(Symbol.getSymbol(key), new UnsignedInteger(value));
+      messageAnnotations.put(Symbol.getSymbol(key), UnsignedInteger.valueOf(value));
       return this;
     }
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, long value) {
-      messageAnnotations.put(Symbol.getSymbol(key), new UnsignedLong(value));
+      messageAnnotations.put(Symbol.getSymbol(key), UnsignedLong.valueOf(value));
       return this;
     }
 
@@ -432,25 +432,25 @@ class QpidProtonMessageBuilder implements MessageBuilder {
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, byte value) {
-      applicationProperties.put(key, new UnsignedByte(value));
+      applicationProperties.put(key, UnsignedByte.valueOf(value));
       return this;
     }
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, short value) {
-      applicationProperties.put(key, new UnsignedShort(value));
+      applicationProperties.put(key, UnsignedShort.valueOf(value));
       return this;
     }
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, int value) {
-      applicationProperties.put(key, new UnsignedInteger(value));
+      applicationProperties.put(key, UnsignedInteger.valueOf(value));
       return this;
     }
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, long value) {
-      applicationProperties.put(key, new UnsignedLong(value));
+      applicationProperties.put(key, UnsignedLong.valueOf(value));
       return this;
     }
 

--- a/src/main/java/com/rabbitmq/stream/codec/SimpleCodec.java
+++ b/src/main/java/com/rabbitmq/stream/codec/SimpleCodec.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -19,6 +19,7 @@ import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageBuilder;
 import com.rabbitmq.stream.Properties;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.netty.buffer.ByteBuf;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -29,11 +30,13 @@ public class SimpleCodec implements Codec {
   @Override
   public EncodedMessage encode(Message message) {
     byte[] body = message.getBodyAsBinary() == null ? EMPTY_BODY : message.getBodyAsBinary();
-    return new EncodedMessage(body.length, body);
+    return new ByteArrayEncodedMessage(body.length, body);
   }
 
   @Override
-  public Message decode(byte[] data) {
+  public Message decode(ByteBuf buf, int length) {
+    byte[] data = new byte[length];
+    buf.readBytes(data);
     return new SimpleMessage(false, 0, data);
   }
 

--- a/src/main/java/com/rabbitmq/stream/codec/StreamingEncodedMessage.java
+++ b/src/main/java/com/rabbitmq/stream/codec/StreamingEncodedMessage.java
@@ -1,0 +1,125 @@
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.codec;
+
+import com.rabbitmq.stream.Codec;
+import com.rabbitmq.stream.Message;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.PooledByteBufAllocator;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * A {@link Codec.EncodedMessage} implementation that encodes a {@link Message} directly into AMQP
+ * 1.0 format on write, without intermediate byte-array materialization.
+ *
+ * <p>When a message is wrapped in a {@code StreamingEncodedMessage}, its exact encoded size is
+ * computed eagerly at construction time. The actual AMQP 1.0 byte encoding is then deferred until
+ * {@link #writeTo(ByteBuf)} or {@link #writeTo(java.io.OutputStream)} is called, so the message is
+ * serialized directly to the target buffer or stream. This avoids allocating a temporary byte array
+ * to hold the full encoded form.
+ *
+ * <p>The supported message sections are message annotations, properties, application properties,
+ * and body (data, amqp-value, or empty data if no body is set).
+ *
+ * <p><strong>This class is experimental and subject to change in future releases.</strong>
+ *
+ * @see Amqp10
+ * @see InternalCodec
+ */
+final class StreamingEncodedMessage implements Codec.EncodedMessage {
+
+  private static final byte[] EMPTY_BODY = new byte[0];
+
+  private final Message message;
+  private final int size;
+
+  public StreamingEncodedMessage(Message message) {
+    this.message = message;
+    this.size = Amqp10.calculateMessageSize(message);
+  }
+
+  @Override
+  public int getSize() {
+    return size;
+  }
+
+  @Override
+  public void writeTo(ByteBuf buf) {
+    buf.writeInt(this.size);
+    // Direct encoding to ByteBuf without intermediate storage
+    encodeMessageToBuf(buf, message);
+  }
+
+  @Override
+  public void writeTo(OutputStream outputStream) throws IOException {
+    // Write size prefix
+    outputStream.write((size >>> 24) & 0xFF);
+    outputStream.write((size >>> 16) & 0xFF);
+    outputStream.write((size >>> 8) & 0xFF);
+    outputStream.write((size >>> 0) & 0xFF);
+
+    // Encode directly to OutputStream via heap ByteBuf with exact size
+    ByteBuf tempBuf = PooledByteBufAllocator.DEFAULT.heapBuffer(size, size);
+    try {
+      encodeMessageToBuf(tempBuf, message);
+      // Direct access to underlying array for optimal performance
+      if (tempBuf.hasArray() && tempBuf.arrayOffset() == 0 && tempBuf.readerIndex() == 0) {
+        outputStream.write(tempBuf.array(), 0, tempBuf.readableBytes());
+      } else {
+        byte[] data = new byte[tempBuf.readableBytes()];
+        tempBuf.readBytes(data);
+        outputStream.write(data);
+      }
+    } finally {
+      tempBuf.release();
+    }
+  }
+
+  private static void encodeMessageToBuf(ByteBuf buf, Message message) {
+    if (message.getMessageAnnotations() != null && !message.getMessageAnnotations().isEmpty()) {
+      Amqp10.writeMessageAnnotations(buf, message.getMessageAnnotations());
+    }
+
+    if (message.getProperties() != null) {
+      Amqp10.writeProperties(buf, message.getProperties());
+    }
+
+    if (message.getApplicationProperties() != null
+        && !message.getApplicationProperties().isEmpty()) {
+      Amqp10.writeApplicationProperties(buf, message.getApplicationProperties());
+    }
+
+    // Body encoding - mirrors InternalCodec.encode logic exactly
+    byte[] bodyBinary = null;
+    try {
+      bodyBinary = message.getBodyAsBinary();
+    } catch (IllegalStateException e) {
+      // non-binary body (e.g. AmqpValue with a String), handled below
+    }
+
+    if (bodyBinary != null) {
+      Amqp10.writeData(buf, bodyBinary);
+    } else {
+      Object body = message.getBody();
+      if (body != null) {
+        Amqp10.writeDescriptor(buf, Amqp10.AMQP_VALUE_DESCRIPTOR);
+        Amqp10.writeObject(buf, body);
+      } else {
+        Amqp10.writeData(buf, EMPTY_BODY);
+      }
+    }
+  }
+}

--- a/src/main/java/com/rabbitmq/stream/codec/SwiftMqCodec.java
+++ b/src/main/java/com/rabbitmq/stream/codec/SwiftMqCodec.java
@@ -275,12 +275,12 @@ public class SwiftMqCodec implements Codec {
           propertiesSet = true;
         }
 
-        if (headers.getAbsoluteExpiryTime() > 0) {
+        if (headers.getAbsoluteExpiryTime() != 0) {
           properties.setAbsoluteExpiryTime(new AMQPTimestamp(headers.getAbsoluteExpiryTime()));
           propertiesSet = true;
         }
 
-        if (headers.getCreationTime() > 0) {
+        if (headers.getCreationTime() != 0) {
           properties.setCreationTime(new AMQPTimestamp(headers.getCreationTime()));
           propertiesSet = true;
         }

--- a/src/main/java/com/rabbitmq/stream/codec/SwiftMqCodec.java
+++ b/src/main/java/com/rabbitmq/stream/codec/SwiftMqCodec.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -57,6 +57,7 @@ import com.swiftmq.amqp.v100.types.AMQPUnsignedLong;
 import com.swiftmq.amqp.v100.types.AMQPUnsignedShort;
 import com.swiftmq.amqp.v100.types.AMQPUuid;
 import com.swiftmq.tools.util.DataByteArrayOutputStream;
+import io.netty.buffer.ByteBuf;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
@@ -351,7 +352,7 @@ public class SwiftMqCodec implements Codec {
       }
       DataByteArrayOutputStream output = new DataByteArrayOutputStream(bufferSize);
       outboundMessage.writeContent(output);
-      return new EncodedMessage(output.getCount(), output.getBuffer());
+      return new ByteArrayEncodedMessage(output.getCount(), output.getBuffer());
     } catch (IOException e) {
       throw new StreamException("Error while writing AMQP 1.0 message to output stream", e);
     }
@@ -501,7 +502,9 @@ public class SwiftMqCodec implements Codec {
   }
 
   @Override
-  public Message decode(byte[] data) {
+  public Message decode(ByteBuf buf, int length) {
+    byte[] data = new byte[length];
+    buf.readBytes(data);
     return createMessage(data);
   }
 

--- a/src/main/java/com/rabbitmq/stream/codec/WrapperMessageBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/codec/WrapperMessageBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -140,25 +140,25 @@ public class WrapperMessageBuilder implements MessageBuilder {
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, byte value) {
-      messageAnnotations.put(key, new UnsignedByte(value));
+      messageAnnotations.put(key, UnsignedByte.valueOf(value));
       return this;
     }
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, short value) {
-      messageAnnotations.put(key, new UnsignedShort(value));
+      messageAnnotations.put(key, UnsignedShort.valueOf(value));
       return this;
     }
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, int value) {
-      messageAnnotations.put(key, new UnsignedInteger(value));
+      messageAnnotations.put(key, UnsignedInteger.valueOf(value));
       return this;
     }
 
     @Override
     public MessageAnnotationsBuilder entryUnsigned(String key, long value) {
-      messageAnnotations.put(key, new UnsignedLong(value));
+      messageAnnotations.put(key, UnsignedLong.valueOf(value));
       return this;
     }
 
@@ -419,25 +419,25 @@ public class WrapperMessageBuilder implements MessageBuilder {
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, byte value) {
-      applicationProperties.put(key, new UnsignedByte(value));
+      applicationProperties.put(key, UnsignedByte.valueOf(value));
       return this;
     }
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, short value) {
-      applicationProperties.put(key, new UnsignedShort(value));
+      applicationProperties.put(key, UnsignedShort.valueOf(value));
       return this;
     }
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, int value) {
-      applicationProperties.put(key, new UnsignedInteger(value));
+      applicationProperties.put(key, UnsignedInteger.valueOf(value));
       return this;
     }
 
     @Override
     public ApplicationPropertiesBuilder entryUnsigned(String key, long value) {
-      applicationProperties.put(key, new UnsignedLong(value));
+      applicationProperties.put(key, UnsignedLong.valueOf(value));
       return this;
     }
 
@@ -514,7 +514,7 @@ public class WrapperMessageBuilder implements MessageBuilder {
     private final boolean hasPublishingId;
     private final long publishingId;
     private final Object body;
-    private final Map<String, Object> messageAnnotations;
+    private Map<String, Object> messageAnnotations;
     private final Properties properties;
     private final Map<String, Object> applicationProperties;
 
@@ -565,7 +565,32 @@ public class WrapperMessageBuilder implements MessageBuilder {
 
     @Override
     public Map<String, Object> getMessageAnnotations() {
+      if (messageAnnotations == null) {
+        messageAnnotations = new LinkedHashMap<>();
+      }
       return messageAnnotations;
+    }
+
+    @Override
+    public Message annotate(String key, Object value) {
+      if (this.messageAnnotations == null) {
+        this.messageAnnotations = new LinkedHashMap<>();
+      }
+      this.messageAnnotations.put(key, value);
+      return this;
+    }
+
+    @Override
+    public Message copy() {
+      Map<String, Object> annotationsCopy =
+          this.messageAnnotations == null ? null : new LinkedHashMap<>(this.messageAnnotations);
+      return new SimpleMessage(
+          this.hasPublishingId,
+          this.publishingId,
+          this.body,
+          annotationsCopy,
+          this.properties,
+          this.applicationProperties);
     }
   }
 
@@ -592,12 +617,15 @@ public class WrapperMessageBuilder implements MessageBuilder {
 
     @Override
     public String getMessageIdAsString() {
-      return (String) messageId;
+      return messageId == null ? null : messageId.toString();
     }
 
     @Override
     public long getMessageIdAsLong() {
-      return (Long) messageId;
+      if (messageId instanceof UnsignedLong) {
+        return ((UnsignedLong) messageId).longValue();
+      }
+      return ((Number) messageId).longValue();
     }
 
     @Override
@@ -637,12 +665,15 @@ public class WrapperMessageBuilder implements MessageBuilder {
 
     @Override
     public String getCorrelationIdAsString() {
-      return (String) correlationId;
+      return correlationId == null ? null : correlationId.toString();
     }
 
     @Override
     public long getCorrelationIdAsLong() {
-      return (long) correlationId;
+      if (correlationId instanceof UnsignedLong) {
+        return ((UnsignedLong) correlationId).longValue();
+      }
+      return ((Number) correlationId).longValue();
     }
 
     @Override

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -2115,7 +2115,7 @@ public class Client implements AutoCloseable {
     @Override
     public void write(ByteBuf bb) {
       for (Codec.EncodedMessage message : messages) {
-        bb.writeInt(message.getSize()).writeBytes(message.getData(), 0, message.getSize());
+        message.writeTo(bb);
       }
     }
 
@@ -2178,12 +2178,7 @@ public class Client implements AutoCloseable {
       this.buffer = allocator.buffer(maxCompressedLength);
       try (OutputStream outputStream = this.codec.compress(new ByteBufOutputStream(buffer))) {
         for (int i = 0; i < messages.size(); i++) {
-          final int size = messages.get(i).getSize();
-          outputStream.write((size >>> 24) & 0xFF);
-          outputStream.write((size >>> 16) & 0xFF);
-          outputStream.write((size >>> 8) & 0xFF);
-          outputStream.write((size >>> 0) & 0xFF);
-          outputStream.write(messages.get(i).getData(), 0, size);
+          messages.get(i).writeTo(outputStream);
         }
         outputStream.flush();
       } catch (Throwable e) {
@@ -2225,8 +2220,7 @@ public class Client implements AutoCloseable {
     @Override
     public int write(ByteBuf bb, Object entity, long publishingId) {
       Codec.EncodedMessage messageToPublish = (Codec.EncodedMessage) entity;
-      bb.writeInt(messageToPublish.getSize());
-      bb.writeBytes(messageToPublish.getData(), 0, messageToPublish.getSize());
+      messageToPublish.writeTo(bb);
       return 1;
     }
 

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -2178,7 +2178,8 @@ public class Client implements AutoCloseable {
       this.buffer = allocator.buffer(maxCompressedLength);
       try (OutputStream outputStream = this.codec.compress(new ByteBufOutputStream(buffer))) {
         for (int i = 0; i < messages.size(); i++) {
-          messages.get(i).writeTo(outputStream);
+          EncodedMessage message = messages.get(i);
+          message.writeTo(outputStream);
         }
         outputStream.flush();
       } catch (Throwable e) {

--- a/src/main/java/com/rabbitmq/stream/impl/Codecs.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Codecs.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -30,9 +30,9 @@ final class Codecs {
   private static Codec instanciateDefault() {
     try {
       return (Codec)
-          Class.forName("com.rabbitmq.stream.codec.QpidProtonCodec").getConstructor().newInstance();
+          Class.forName("com.rabbitmq.stream.codec.InternalCodec").getConstructor().newInstance();
     } catch (Exception e) {
-      throw new StreamException("Error while creating QPid Proton codec", e);
+      throw new StreamException("Error while creating internal codec", e);
     }
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
@@ -372,15 +372,14 @@ class ServerFrameHandler {
         Object chunkContext) {
       int entrySize = bb.readInt();
       read += 4;
-      byte[] data = new byte[entrySize];
-      bb.readBytes(data);
       read += entrySize;
 
       if (ignore && Long.compareUnsigned(offset, offsetLimit) < 0) {
+        bb.skipBytes(entrySize);
         messageIgnored.set(true);
       } else {
         try {
-          Message message = codec.decode(data);
+          Message message = codec.decode(bb, entrySize);
           messageListener.handle(
               subscriptionId, offset, chunkTimestamp, committedChunkId, chunkContext, message);
         } catch (RuntimeException e) {

--- a/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamProducer.java
@@ -651,8 +651,7 @@ final class StreamProducer extends ResourceBase implements Producer {
       }
       Codec.EncodedMessage messageToPublish =
           (Codec.EncodedMessage) accumulatedEntity.encodedEntity();
-      bb.writeInt(messageToPublish.getSize());
-      bb.writeBytes(messageToPublish.getData(), 0, messageToPublish.getSize());
+      messageToPublish.writeTo(bb);
       return 1;
     }
 

--- a/src/test/java/com/rabbitmq/stream/benchmark/EncodeDecodeForPerformanceToolBenchmark.java
+++ b/src/test/java/com/rabbitmq/stream/benchmark/EncodeDecodeForPerformanceToolBenchmark.java
@@ -49,7 +49,8 @@ public class EncodeDecodeForPerformanceToolBenchmark {
   @Param({
     "com.rabbitmq.stream.codec.QpidProtonCodec",
     "com.rabbitmq.stream.codec.SwiftMqCodec",
-    "com.rabbitmq.stream.codec.SimpleCodec"
+    "com.rabbitmq.stream.codec.SimpleCodec",
+    "com.rabbitmq.stream.codec.InternalCodec"
   })
   String codecClass;
 

--- a/src/test/java/com/rabbitmq/stream/benchmark/EncodeDecodeForPerformanceToolBenchmark.java
+++ b/src/test/java/com/rabbitmq/stream/benchmark/EncodeDecodeForPerformanceToolBenchmark.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -14,8 +14,11 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.benchmark;
 
+import static com.rabbitmq.stream.impl.TestUtils.encodedMessageByteBuf;
+
 import com.rabbitmq.stream.Codec;
 import com.rabbitmq.stream.Message;
+import io.netty.buffer.ByteBuf;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -60,7 +63,7 @@ public class EncodeDecodeForPerformanceToolBenchmark {
 
   TimestampProvider timestampProvider;
 
-  byte[] messageToDecode;
+  ByteBuf messageToDecode;
 
   @Setup
   public void setUp() throws Exception {
@@ -76,8 +79,7 @@ public class EncodeDecodeForPerformanceToolBenchmark {
     byte[] payload = new byte[payloadSize];
     writeLong(payload, timestampProvider.get());
     Codec.EncodedMessage encoded = codec.encode(codec.messageBuilder().addData(payload).build());
-    messageToDecode = new byte[encoded.getSize()];
-    System.arraycopy(encoded.getData(), 0, messageToDecode, 0, encoded.getSize());
+    messageToDecode = encodedMessageByteBuf(encoded);
   }
 
   @Benchmark
@@ -89,7 +91,9 @@ public class EncodeDecodeForPerformanceToolBenchmark {
 
   @Benchmark
   public void decode() {
-    Message message = codec.decode(messageToDecode);
+    messageToDecode.markReaderIndex();
+    Message message = codec.decode(messageToDecode, messageToDecode.readableBytes());
+    messageToDecode.resetReaderIndex();
     long latency = timestampProvider.get() - readLong(message.getBodyAsBinary());
   }
 

--- a/src/test/java/com/rabbitmq/stream/benchmark/EncodingDecodingBenchmark.java
+++ b/src/test/java/com/rabbitmq/stream/benchmark/EncodingDecodingBenchmark.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -14,7 +14,10 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.benchmark;
 
+import static com.rabbitmq.stream.impl.TestUtils.encodedMessageByteBuf;
+
 import com.rabbitmq.stream.Codec;
+import io.netty.buffer.ByteBuf;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -52,7 +55,7 @@ public class EncodingDecodingBenchmark {
   Codec codec;
   byte[] payload;
 
-  byte[] messageToDecode;
+  ByteBuf messageToDecode;
 
   @Setup
   public void setUp() throws Exception {
@@ -70,8 +73,7 @@ public class EncodingDecodingBenchmark {
                 .addData(payload)
                 .build());
 
-    messageToDecode = new byte[encoded.getSize()];
-    System.arraycopy(encoded.getData(), 0, messageToDecode, 0, encoded.getSize());
+    messageToDecode = encodedMessageByteBuf(encoded);
   }
 
   @Benchmark
@@ -88,7 +90,9 @@ public class EncodingDecodingBenchmark {
 
   @Benchmark
   public void decode() {
-    codec.decode(messageToDecode);
+    messageToDecode.markReaderIndex();
+    codec.decode(messageToDecode, messageToDecode.readableBytes());
+    messageToDecode.resetReaderIndex();
   }
 
   public static void main(String[] args) throws RunnerException {

--- a/src/test/java/com/rabbitmq/stream/benchmark/EncodingDecodingBenchmark.java
+++ b/src/test/java/com/rabbitmq/stream/benchmark/EncodingDecodingBenchmark.java
@@ -46,7 +46,11 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Threads(1)
 public class EncodingDecodingBenchmark {
 
-  @Param({"com.rabbitmq.stream.codec.QpidProtonCodec", "com.rabbitmq.stream.codec.SwiftMqCodec"})
+  @Param({
+    "com.rabbitmq.stream.codec.QpidProtonCodec",
+    "com.rabbitmq.stream.codec.SwiftMqCodec",
+    "com.rabbitmq.stream.codec.InternalCodec"
+  })
   String codecClass;
 
   @Param({"20"})

--- a/src/test/java/com/rabbitmq/stream/codec/CodecsTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/CodecsTest.java
@@ -46,6 +46,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.AmqpValue;
@@ -63,7 +65,7 @@ public class CodecsTest {
   static UUID TEST_UUID = UUID.randomUUID();
 
   static Iterable<CodecCouple> codecsCouples() {
-    List<Codec> codecs = asList(new QpidProtonCodec(), new SwiftMqCodec());
+    List<Codec> codecs = asList(new QpidProtonCodec(), new SwiftMqCodec(), new InternalCodec());
     List<CodecCouple> couples = new ArrayList<>();
     for (Codec serializer : codecs) {
       for (Codec deserializer : codecs) {
@@ -75,7 +77,7 @@ public class CodecsTest {
   }
 
   static Iterable<CodecCouple> codecsCombinations() {
-    List<Codec> codecs = asList(new QpidProtonCodec(), new SwiftMqCodec());
+    List<Codec> codecs = asList(new QpidProtonCodec(), new SwiftMqCodec(), new InternalCodec());
     List<CodecCouple> couples = new ArrayList<>();
     for (Codec serializer : codecs) {
       for (Codec deserializer : codecs) {
@@ -87,18 +89,22 @@ public class CodecsTest {
 
   static Iterable<Supplier<MessageBuilder>> messageBuilderSuppliers() {
     return asList(
-        QpidProtonMessageBuilder::new, SwiftMqMessageBuilder::new, WrapperMessageBuilder::new);
+        QpidProtonMessageBuilder::new,
+        SwiftMqMessageBuilder::new,
+        WrapperMessageBuilder::new,
+        new InternalCodec()::messageBuilder);
   }
 
   static Iterable<Codec> readCreatedMessage() {
     return asList(
         when(mock(Codec.class).messageBuilder()).thenReturn(new WrapperMessageBuilder()).getMock(),
         new QpidProtonCodec(),
-        new SwiftMqCodec());
+        new SwiftMqCodec(),
+        new InternalCodec());
   }
 
   static Stream<Codec> allAmqpCodecs() {
-    return Stream.of(new QpidProtonCodec(), new SwiftMqCodec());
+    return Stream.of(new QpidProtonCodec(), new SwiftMqCodec(), new InternalCodec());
   }
 
   static Stream<MessageBuilder> messageBuilders() {
@@ -106,7 +112,8 @@ public class CodecsTest {
         new QpidProtonMessageBuilder(),
         new SwiftMqMessageBuilder(),
         new WrapperMessageBuilder(),
-        new SimpleCodec().messageBuilder());
+        new SimpleCodec().messageBuilder(),
+        new InternalCodec().messageBuilder());
   }
 
   @ParameterizedTest
@@ -370,10 +377,15 @@ public class CodecsTest {
               .isNotNull()
               .isInstanceOf(Double.class)
               .isEqualTo(Double.valueOf(6.28));
-          assertThat(inboundMessage.getApplicationProperties().get("char"))
-              .isNotNull()
-              .isInstanceOf(Character.class)
-              .isEqualTo('c');
+          // InternalCodec returns Integer (full Unicode support per AMQP 1.0 spec)
+          // QpidProtonCodec and SwiftMqCodec return Character (16-bit, truncated)
+          Object charValue = inboundMessage.getApplicationProperties().get("char");
+          assertThat(charValue).isNotNull();
+          if (codecCouple.deserializer instanceof InternalCodec) {
+            assertThat(charValue).isInstanceOf(Integer.class).isEqualTo((int) 'c');
+          } else {
+            assertThat(charValue).isInstanceOf(Character.class).isEqualTo('c');
+          }
           assertThat(inboundMessage.getApplicationProperties().get("timestamp"))
               .isNotNull()
               .isInstanceOf(Long.class)
@@ -468,10 +480,16 @@ public class CodecsTest {
               .isNotNull()
               .isInstanceOf(Double.class)
               .isEqualTo(Double.valueOf(6.28));
-          assertThat(inboundMessage.getMessageAnnotations().get("annotations.char"))
-              .isNotNull()
-              .isInstanceOf(Character.class)
-              .isEqualTo('c');
+          // InternalCodec returns Integer (full Unicode support per AMQP 1.0 spec)
+          // QpidProtonCodec and SwiftMqCodec return Character (16-bit, truncated)
+          Object annotationCharValue =
+              inboundMessage.getMessageAnnotations().get("annotations.char");
+          assertThat(annotationCharValue).isNotNull();
+          if (codecCouple.deserializer instanceof InternalCodec) {
+            assertThat(annotationCharValue).isInstanceOf(Integer.class).isEqualTo((int) 'c');
+          } else {
+            assertThat(annotationCharValue).isInstanceOf(Character.class).isEqualTo('c');
+          }
           assertThat(inboundMessage.getMessageAnnotations().get("annotations.timestamp"))
               .isNotNull()
               .isInstanceOf(Long.class)
@@ -527,6 +545,107 @@ public class CodecsTest {
           }
           assertThat(arrayInt).containsExactly(200, 201, 202);
         });
+  }
+
+  @ParameterizedTest
+  @MethodSource("codecsCouples")
+  void codecsLargeComposites(CodecCouple codecCouple) {
+    Codec serializer = codecCouple.serializer;
+    Codec deserializer = codecCouple.deserializer;
+
+    MessageBuilder messageBuilder = codecCouple.messageBuilderSupplier.get();
+
+    List<String> largeList =
+        IntStream.range(0, 30).mapToObj(i -> "list-element-" + i).collect(Collectors.toList());
+    Map<String, Object> largeMap = new LinkedHashMap<>();
+    for (int i = 0; i < 30; i++) {
+      largeMap.put("map-key-" + i, "map-value-" + i);
+    }
+    String[] largeStringArray =
+        IntStream.range(0, 30).mapToObj(i -> "arr-element-" + i).toArray(String[]::new);
+    Integer[] largeIntArray =
+        IntStream.range(0, 30).mapToObj(i -> 1000 + i).toArray(Integer[]::new);
+
+    MessageBuilder.MessageAnnotationsBuilder annotations = messageBuilder.messageAnnotations();
+    annotations
+        .entry("large-list", largeList)
+        .entry("large-map", largeMap)
+        .entryArray("large-string-array", largeStringArray)
+        .entryArray("large-int-array", largeIntArray);
+    for (int i = 0; i < 30; i++) {
+      annotations.entry("annotation-key-" + i, "annotation-value-" + i);
+    }
+
+    MessageBuilder.ApplicationPropertiesBuilder appProps =
+        annotations.messageBuilder().applicationProperties();
+    for (int i = 0; i < 30; i++) {
+      appProps.entry("app-prop-key-" + i, "app-prop-value-" + i);
+    }
+
+    Message outboundMessage =
+        appProps
+            .messageBuilder()
+            .properties()
+            .messageId("large-composites-test")
+            .to("destination")
+            .subject("subject")
+            .contentType("application/octet-stream")
+            .messageBuilder()
+            .addData("large composites body".getBytes(CHARSET))
+            .build();
+
+    Codec.EncodedMessage encoded = serializer.encode(outboundMessage);
+    ByteBuf encodedData = encodedMessageByteBuf(encoded);
+    Message inboundMessage = deserializer.decode(encodedData, encodedData.readableBytes());
+
+    assertThat(new String(inboundMessage.getBodyAsBinary(), CHARSET))
+        .isEqualTo("large composites body");
+    assertThat(inboundMessage.getProperties().getMessageIdAsString())
+        .isEqualTo("large-composites-test");
+    assertThat(inboundMessage.getProperties().getTo()).isEqualTo("destination");
+    assertThat(inboundMessage.getProperties().getSubject()).isEqualTo("subject");
+    assertThat(inboundMessage.getProperties().getContentType())
+        .isEqualTo("application/octet-stream");
+
+    assertThat(inboundMessage.getApplicationProperties()).hasSize(30);
+    for (int i = 0; i < 30; i++) {
+      assertThat(inboundMessage.getApplicationProperties().get("app-prop-key-" + i))
+          .isEqualTo("app-prop-value-" + i);
+    }
+
+    assertThat(inboundMessage.getMessageAnnotations()).hasSizeGreaterThanOrEqualTo(30 + 4);
+    for (int i = 0; i < 30; i++) {
+      assertThat(inboundMessage.getMessageAnnotations().get("annotation-key-" + i))
+          .isEqualTo("annotation-value-" + i);
+    }
+
+    List<?> decodedList = (List<?>) inboundMessage.getMessageAnnotations().get("large-list");
+    assertThat(decodedList).hasSize(30);
+    assertThat(decodedList.get(0)).isEqualTo("list-element-0");
+    assertThat(decodedList.get(29)).isEqualTo("list-element-29");
+
+    Map<?, ?> decodedMap = (Map<?, ?>) inboundMessage.getMessageAnnotations().get("large-map");
+    assertThat(decodedMap).hasSize(30);
+    assertThat(decodedMap.get("map-key-0")).isEqualTo("map-value-0");
+    assertThat(decodedMap.get("map-key-29")).isEqualTo("map-value-29");
+
+    Object[] decodedStringArray =
+        (Object[]) inboundMessage.getMessageAnnotations().get("large-string-array");
+    assertThat(decodedStringArray).hasSize(30);
+    assertThat(decodedStringArray[0]).isEqualTo("arr-element-0");
+    assertThat(decodedStringArray[29]).isEqualTo("arr-element-29");
+
+    int[] decodedIntArray;
+    Object rawIntArray = inboundMessage.getMessageAnnotations().get("large-int-array");
+    if (rawIntArray instanceof Integer[]) {
+      decodedIntArray =
+          Arrays.stream((Integer[]) rawIntArray).mapToInt(Integer::intValue).toArray();
+    } else {
+      decodedIntArray = (int[]) rawIntArray;
+    }
+    assertThat(decodedIntArray).hasSize(30);
+    assertThat(decodedIntArray[0]).isEqualTo(1000);
+    assertThat(decodedIntArray[29]).isEqualTo(1029);
   }
 
   @ParameterizedTest

--- a/src/test/java/com/rabbitmq/stream/codec/CodecsTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/CodecsTest.java
@@ -649,6 +649,51 @@ public class CodecsTest {
   }
 
   @ParameterizedTest
+  @MethodSource("codecsCouples")
+  void codecsMultiByteUtf8(CodecCouple codecCouple) {
+    Codec serializer = codecCouple.serializer;
+    Codec deserializer = codecCouple.deserializer;
+
+    // 2-byte UTF-8 chars at the STR8/STR32 boundary (128 * 2 = 256 bytes, forces STR32)
+    String twoByteStr = "\u00E9".repeat(128);
+    // 3-byte UTF-8 chars (CJK ideographs, 86 * 3 = 258 bytes)
+    String threeByteStr = "\u4E00".repeat(86);
+    // 4-byte UTF-8 chars (emoji, 64 * 4 = 256 bytes)
+    String fourByteStr = new String(Character.toChars(0x1F600)).repeat(64);
+    // Exactly 255 UTF-8 bytes: stays in STR8
+    String str8Boundary = "\u00E9".repeat(127) + "x";
+
+    MessageBuilder messageBuilder = codecCouple.messageBuilderSupplier.get();
+    Message outboundMessage =
+        messageBuilder
+            .applicationProperties()
+            .entry("two-byte", twoByteStr)
+            .entry("three-byte", threeByteStr)
+            .entry("four-byte", fourByteStr)
+            .entry("str8-boundary", str8Boundary)
+            .messageBuilder()
+            .properties()
+            .messageId(twoByteStr)
+            .subject(threeByteStr)
+            .messageBuilder()
+            .addData("body".getBytes(CHARSET))
+            .build();
+
+    Codec.EncodedMessage encoded = serializer.encode(outboundMessage);
+    ByteBuf encodedData = encodedMessageByteBuf(encoded);
+    Message inboundMessage = deserializer.decode(encodedData, encodedData.readableBytes());
+
+    assertThat(inboundMessage.getApplicationProperties().get("two-byte")).isEqualTo(twoByteStr);
+    assertThat(inboundMessage.getApplicationProperties().get("three-byte")).isEqualTo(threeByteStr);
+    assertThat(inboundMessage.getApplicationProperties().get("four-byte")).isEqualTo(fourByteStr);
+    assertThat(inboundMessage.getApplicationProperties().get("str8-boundary"))
+        .isEqualTo(str8Boundary);
+    assertThat(inboundMessage.getProperties().getMessageIdAsString()).isEqualTo(twoByteStr);
+    assertThat(inboundMessage.getProperties().getSubject()).isEqualTo(threeByteStr);
+    assertThat(new String(inboundMessage.getBodyAsBinary(), CHARSET)).isEqualTo("body");
+  }
+
+  @ParameterizedTest
   @MethodSource
   void readCreatedMessage(Codec codec) {
     // same conversion logic as for encoding/decoding, so not testing all types

--- a/src/test/java/com/rabbitmq/stream/codec/CodecsTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/CodecsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -14,6 +14,7 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.codec;
 
+import static com.rabbitmq.stream.impl.TestUtils.encodedMessageByteBuf;
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -29,6 +30,7 @@ import com.rabbitmq.stream.amqp.UnsignedInteger;
 import com.rabbitmq.stream.amqp.UnsignedLong;
 import com.rabbitmq.stream.amqp.UnsignedShort;
 import com.rabbitmq.stream.codec.QpidProtonCodec.QpidProtonAmqpMessageWrapper;
+import io.netty.buffer.ByteBuf;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.charset.Charset;
@@ -276,9 +278,8 @@ public class CodecsTest {
 
           Codec.EncodedMessage encoded = serializer.encode(outboundMessage);
 
-          byte[] encodedData = new byte[encoded.getSize()];
-          System.arraycopy(encoded.getData(), 0, encodedData, 0, encoded.getSize());
-          Message inboundMessage = deserializer.decode(encodedData);
+          ByteBuf encodedData = encodedMessageByteBuf(encoded);
+          Message inboundMessage = deserializer.decode(encodedData, encodedData.readableBytes());
 
           messageExpectation.accept(inboundMessage);
 
@@ -595,9 +596,8 @@ public class CodecsTest {
           QpidProtonAmqpMessageWrapper wrapper =
               new QpidProtonAmqpMessageWrapper(true, 1L, nativeMessage);
           EncodedMessage encoded = new QpidProtonCodec().encode(wrapper);
-          byte[] encodedData = new byte[encoded.getSize()];
-          System.arraycopy(encoded.getData(), 0, encodedData, 0, encoded.getSize());
-          return codec.decode(encodedData);
+          ByteBuf buf = encodedMessageByteBuf(encoded);
+          return codec.decode(buf, buf.readableBytes());
         };
 
     Message m1 = encodeDecode.apply("hello".getBytes(StandardCharsets.UTF_8));
@@ -656,9 +656,8 @@ public class CodecsTest {
     UnaryOperator<Message> encodeDecode =
         msg -> {
           EncodedMessage encoded = serializer.encode(msg);
-          byte[] encodedData = new byte[encoded.getSize()];
-          System.arraycopy(encoded.getData(), 0, encodedData, 0, encoded.getSize());
-          return deserializer.decode(encodedData);
+          ByteBuf buf = encodedMessageByteBuf(encoded);
+          return deserializer.decode(buf, buf.readableBytes());
         };
 
     message = encodeDecode.apply(message);

--- a/src/test/java/com/rabbitmq/stream/codec/InternalCodecTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/InternalCodecTest.java
@@ -294,6 +294,93 @@ public class InternalCodecTest {
   }
 
   @Test
+  void multiByteUtf8StringRoundTrip() {
+    // 2-byte UTF-8 characters (Latin Extended, U+00E0..U+00FF): each char = 2 bytes
+    // 128 such chars = 256 UTF-8 bytes, forcing STR32 despite only 128 characters
+    String twoByteChars = "\u00E9".repeat(128);
+    assertThat(twoByteChars.length()).isEqualTo(128);
+    assertThat(twoByteChars.getBytes(java.nio.charset.StandardCharsets.UTF_8).length)
+        .isEqualTo(256);
+
+    // 3-byte UTF-8 characters (CJK, U+4E00): each char = 3 bytes
+    String threeByteChars = "\u4E00".repeat(86);
+    assertThat(threeByteChars.getBytes(java.nio.charset.StandardCharsets.UTF_8).length)
+        .isEqualTo(258);
+
+    // 4-byte UTF-8 characters (emoji, U+1F600): each code point = 4 bytes, 2 Java chars
+    String fourByteChars = new String(Character.toChars(0x1F600)).repeat(64);
+    assertThat(fourByteChars.getBytes(java.nio.charset.StandardCharsets.UTF_8).length)
+        .isEqualTo(256);
+
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .applicationProperties()
+            .entry("two-byte", twoByteChars)
+            .entry("three-byte", threeByteChars)
+            .entry("four-byte", fourByteChars)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getApplicationProperties().get("two-byte")).isEqualTo(twoByteChars);
+    assertThat(decoded.getApplicationProperties().get("three-byte")).isEqualTo(threeByteChars);
+    assertThat(decoded.getApplicationProperties().get("four-byte")).isEqualTo(fourByteChars);
+  }
+
+  @Test
+  void multiByteUtf8StringAtStr8Str32Boundary() {
+    // Exactly 255 UTF-8 bytes: should use STR8
+    String justUnder = "\u00E9".repeat(127) + "x";
+    assertThat(justUnder.getBytes(java.nio.charset.StandardCharsets.UTF_8).length).isEqualTo(255);
+
+    // Exactly 256 UTF-8 bytes: must use STR32
+    String justOver = "\u00E9".repeat(128);
+    assertThat(justOver.getBytes(java.nio.charset.StandardCharsets.UTF_8).length).isEqualTo(256);
+
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .applicationProperties()
+            .entry("str8", justUnder)
+            .entry("str32", justOver)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getApplicationProperties().get("str8")).isEqualTo(justUnder);
+    assertThat(decoded.getApplicationProperties().get("str32")).isEqualTo(justOver);
+  }
+
+  @Test
+  void multiByteUtf8InPropertiesRoundTrip() {
+    String twoByteStr = "\u00E9".repeat(128);
+    String threeByteStr = "\u4E00".repeat(86);
+
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(twoByteStr)
+            .to(threeByteStr)
+            .subject(twoByteStr)
+            .correlationId(threeByteStr)
+            .groupId(twoByteStr)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getProperties().getMessageIdAsString()).isEqualTo(twoByteStr);
+    assertThat(decoded.getProperties().getTo()).isEqualTo(threeByteStr);
+    assertThat(decoded.getProperties().getSubject()).isEqualTo(twoByteStr);
+    assertThat(decoded.getProperties().getCorrelationIdAsString()).isEqualTo(threeByteStr);
+    assertThat(decoded.getProperties().getGroupId()).isEqualTo(twoByteStr);
+  }
+
+  @Test
   void largePropertiesRoundTrip() {
     String longString = "x".repeat(300);
     Message msg =

--- a/src/test/java/com/rabbitmq/stream/codec/InternalCodecTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/InternalCodecTest.java
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rabbitmq.stream.Codec;
+import com.rabbitmq.stream.Message;
+import com.rabbitmq.stream.MessageBuilder;
+import com.rabbitmq.stream.Properties;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+public class InternalCodecTest {
+
+  private static final Codec CODEC = new InternalCodec();
+
+  @Test
+  void testEmptyProperties() {
+    MessageBuilder builder = CODEC.messageBuilder();
+    builder.properties().groupId(null);
+    Message msg = builder.build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(msg);
+    ByteBuf buf = Unpooled.buffer(encoded.getSize() + 4);
+    encoded.writeTo(buf);
+    buf.readInt(); // skip size
+    Message decoded = CODEC.decode(buf, encoded.getSize());
+
+    Properties properties = decoded.getProperties();
+    assertThat(properties).isNotNull();
+    assertThat(properties.getGroupId()).isNull();
+  }
+
+  @Test
+  void testCharIsReturnedAsInt() {
+    // AMQP 1.0 defines char as a UTF-32 code point (4 bytes, full Unicode range).
+    // Java's char type is only 16-bit and cannot represent characters above U+FFFF
+    // (supplementary plane characters like emoji). The InternalCodec correctly
+    // returns int (32-bit) to preserve the full Unicode range, while other codecs
+    // truncate to Java's char type and lose data for supplementary characters.
+    MessageBuilder builder = CODEC.messageBuilder();
+    // Basic ASCII character - works in all codecs
+    builder.applicationProperties().entry("ascii", (char) 'A');
+    Message msg = builder.build();
+    Codec.EncodedMessage encoded = CODEC.encode(msg);
+    ByteBuf buf = Unpooled.buffer(encoded.getSize() + 4);
+    encoded.writeTo(buf);
+    buf.readInt();
+    Message decoded = CODEC.decode(buf, encoded.getSize());
+
+    Map<String, Object> props = decoded.getApplicationProperties();
+    // ASCII character: InternalCodec returns int, other codecs would return char
+    assertThat(props.get("ascii")).isInstanceOf(Integer.class).isEqualTo((int) 'A');
+  }
+
+  @Test
+  void testCharSupplementaryPlane() {
+    // AMQP 1.0 defines char as a UTF-32 code point (4 bytes, full Unicode range).
+    // Java's char type is only 16-bit and cannot represent characters above U+FFFF
+    // (supplementary plane characters like emoji). The InternalCodec correctly
+    // returns int (32-bit) to preserve the full Unicode range, while other codecs
+    // truncate to Java's char type and lose data for supplementary characters.
+
+    // Emoji (supplementary plane) - would be truncated by other codecs
+    // 0x1F600 = 😀 (grinning face emoji)
+    int emojiCodePoint = 0x1F600;
+    // We can't use Java's char for this since char can't hold values > 0xFFFF
+    // So we manually encode it using the internal AMQP char type
+    ByteBuf tempBuf = Unpooled.buffer();
+    tempBuf.writeByte(0x73); // AMQP char type code
+    tempBuf.writeInt(emojiCodePoint);
+
+    // Test emoji by directly decoding AMQP char bytes
+    Object emojiResult = com.rabbitmq.stream.codec.Amqp10.readObject(tempBuf);
+    assertThat(emojiResult).isInstanceOf(Integer.class).isEqualTo(emojiCodePoint);
+
+    // If other codecs tried to handle this emoji:
+    // - They would cast to (char) and get: (char) 0x1F600 = '\uF600' (wrong!)
+    // - The high bits (0x1F000) would be lost, corrupting the character
+    char truncated = (char) emojiCodePoint;
+    assertThat(truncated).isNotEqualTo(emojiCodePoint); // Demonstrates data loss
+    assertThat((int) truncated).isEqualTo(0xF600); // Only lower 16 bits preserved
+  }
+
+  @Test
+  void smallApplicationPropertiesRoundTrip() {
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .applicationProperties()
+            .entry("k", "v")
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getApplicationProperties()).containsEntry("k", "v");
+    assertThat(decoded.getBodyAsBinary()).isEqualTo("x".getBytes());
+  }
+
+  @Test
+  void largeApplicationPropertiesRoundTrip() {
+    MessageBuilder.ApplicationPropertiesBuilder appProps =
+        CODEC.messageBuilder().applicationProperties();
+    for (int i = 0; i < 50; i++) {
+      appProps.entry("key-with-long-name-" + i, "value-with-long-content-" + i);
+    }
+    Message msg = appProps.messageBuilder().addData("payload".getBytes()).build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getApplicationProperties()).hasSize(50);
+    assertThat(decoded.getApplicationProperties().get("key-with-long-name-0"))
+        .isEqualTo("value-with-long-content-0");
+    assertThat(decoded.getApplicationProperties().get("key-with-long-name-49"))
+        .isEqualTo("value-with-long-content-49");
+  }
+
+  @Test
+  void smallMessageAnnotationsRoundTrip() {
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("a", "b")
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getMessageAnnotations()).containsEntry("a", "b");
+  }
+
+  @Test
+  void largeMessageAnnotationsRoundTrip() {
+    MessageBuilder.MessageAnnotationsBuilder annotations =
+        CODEC.messageBuilder().messageAnnotations();
+    for (int i = 0; i < 50; i++) {
+      annotations.entry("annotation-key-" + i, "annotation-value-" + i);
+    }
+    Message msg = annotations.messageBuilder().addData("payload".getBytes()).build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getMessageAnnotations()).hasSize(50);
+    assertThat(decoded.getMessageAnnotations().get("annotation-key-0"))
+        .isEqualTo("annotation-value-0");
+  }
+
+  @Test
+  void smallNestedListRoundTrip() {
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("list", List.of("a", "b"))
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    @SuppressWarnings("unchecked")
+    List<Object> list = (List<Object>) decoded.getMessageAnnotations().get("list");
+    assertThat(list).containsExactly("a", "b");
+  }
+
+  @Test
+  void largeNestedListRoundTrip() {
+    List<String> largeList =
+        IntStream.range(0, 50)
+            .mapToObj(i -> "element-with-some-content-" + i)
+            .collect(Collectors.toList());
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("large-list", largeList)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    List<?> list = (List<?>) decoded.getMessageAnnotations().get("large-list");
+    assertThat(list).hasSize(50);
+    assertThat(list.get(0)).isEqualTo("element-with-some-content-0");
+    assertThat(list.get(49)).isEqualTo("element-with-some-content-49");
+  }
+
+  @Test
+  void smallNestedMapRoundTrip() {
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("map", Map.of("k1", "v1"))
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> map = (Map<String, Object>) decoded.getMessageAnnotations().get("map");
+    assertThat(map).containsEntry("k1", "v1");
+  }
+
+  @Test
+  void largeNestedMapRoundTrip() {
+    Map<String, Object> largeMap = new LinkedHashMap<>();
+    for (int i = 0; i < 50; i++) {
+      largeMap.put("map-key-" + i, "map-value-" + i);
+    }
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("large-map", largeMap)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    Map<?, ?> map = (Map<?, ?>) decoded.getMessageAnnotations().get("large-map");
+    assertThat(map).hasSize(50);
+    assertThat(map.get("map-key-0")).isEqualTo("map-value-0");
+    assertThat(map.get("map-key-49")).isEqualTo("map-value-49");
+  }
+
+  @Test
+  void smallArrayRoundTrip() {
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entryArray("arr", new String[] {"a", "b"})
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    Object[] arr = (Object[]) decoded.getMessageAnnotations().get("arr");
+    assertThat(arr).containsExactly("a", "b");
+  }
+
+  @Test
+  void largeArrayRoundTrip() {
+    String[] largeArray =
+        IntStream.range(0, 50).mapToObj(i -> "element-" + i).toArray(String[]::new);
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entryArray("large-arr", largeArray)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    Object[] arr = (Object[]) decoded.getMessageAnnotations().get("large-arr");
+    assertThat(arr).hasSize(50);
+    assertThat(arr[0]).isEqualTo("element-0");
+    assertThat(arr[49]).isEqualTo("element-49");
+  }
+
+  @Test
+  void smallPropertiesRoundTrip() {
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(1L)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getProperties().getMessageIdAsLong()).isEqualTo(1L);
+  }
+
+  @Test
+  void largePropertiesRoundTrip() {
+    String longString = "x".repeat(300);
+    Message msg =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(longString)
+            .to(longString)
+            .subject(longString)
+            .replyTo(longString)
+            .correlationId(longString)
+            .groupId(longString)
+            .replyToGroupId(longString)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    Message decoded = encodeDecode(msg);
+    assertThat(decoded.getProperties().getMessageIdAsString()).isEqualTo(longString);
+    assertThat(decoded.getProperties().getTo()).isEqualTo(longString);
+    assertThat(decoded.getProperties().getSubject()).isEqualTo(longString);
+    assertThat(decoded.getProperties().getReplyTo()).isEqualTo(longString);
+    assertThat(decoded.getProperties().getCorrelationIdAsString()).isEqualTo(longString);
+    assertThat(decoded.getProperties().getGroupId()).isEqualTo(longString);
+    assertThat(decoded.getProperties().getReplyToGroupId()).isEqualTo(longString);
+  }
+
+  private Message encodeDecode(Message msg) {
+    Codec.EncodedMessage encoded = CODEC.encode(msg);
+    ByteBuf buf = Unpooled.buffer(encoded.getSize() + 4);
+    encoded.writeTo(buf);
+    buf.readInt();
+    return CODEC.decode(buf, encoded.getSize());
+  }
+}

--- a/src/test/java/com/rabbitmq/stream/codec/StreamingEncodedMessageTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/StreamingEncodedMessageTest.java
@@ -1,0 +1,445 @@
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.codec;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.rabbitmq.stream.Codec;
+import com.rabbitmq.stream.Message;
+import com.rabbitmq.stream.MessageBuilder;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class StreamingEncodedMessageTest {
+
+  private static final InternalCodec CODEC = new InternalCodec();
+
+  ByteBuf buf;
+
+  @BeforeEach
+  void setUp() {
+    buf = Unpooled.buffer();
+  }
+
+  @AfterEach
+  void tearDown() {
+    buf.release();
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSimpleMessage() {
+    Message message = CODEC.messageBuilder().addData("Hello World".getBytes()).build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+
+    // Verify size matches actual encoded data (ByteBuf now includes 4-byte size prefix)
+    encoded.writeTo(buf);
+
+    // ByteBuf contains: [4-byte size] + [message content]
+    // So total ByteBuf size should be: size + 4
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize() + 4);
+
+    // Verify the size prefix is correct
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(encoded.getSize());
+
+    // Remaining bytes should match the message size
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize());
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForComplexMessage() {
+    UUID messageId = UUID.randomUUID();
+    long currentTime = System.currentTimeMillis();
+
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("x-routing-key", "test.routing.key")
+            .entry("x-priority", (byte) 5)
+            .entry("x-delay", 1000)
+            .messageBuilder()
+            .properties()
+            .messageId(messageId)
+            .userId("test-user".getBytes())
+            .to("test-destination")
+            .subject("test-subject")
+            .replyTo("test-reply")
+            .correlationId("correlation-123")
+            .contentType("application/json")
+            .contentEncoding("utf-8")
+            .absoluteExpiryTime(currentTime + 60000)
+            .creationTime(currentTime)
+            .groupId("test-group")
+            .groupSequence(1L)
+            .replyToGroupId("reply-group")
+            .messageBuilder()
+            .applicationProperties()
+            .entry("string-prop", "test-value")
+            .entry("int-prop", 42)
+            .entry("long-prop", 123456789L)
+            .entry("boolean-prop", true)
+            .entry("uuid-prop", UUID.randomUUID())
+            .entry("binary-prop", "binary-data".getBytes())
+            .messageBuilder()
+            .addData("{\"message\": \"complex test data with unicode: ñáéíóú\"}".getBytes())
+            .build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+
+    // Verify size matches actual encoded data (ByteBuf now includes 4-byte size prefix)
+    encoded.writeTo(buf);
+
+    // ByteBuf contains: [4-byte size] + [message content]
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize() + 4);
+
+    // Verify the size prefix
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(encoded.getSize());
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForMessageWithProperties() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(12345L)
+            .contentType("application/json")
+            .messageBuilder()
+            .addData("Test data with properties".getBytes())
+            .build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+
+    // Verify size matches actual encoded data (ByteBuf now includes 4-byte size prefix)
+    encoded.writeTo(buf);
+
+    // ByteBuf contains: [4-byte size] + [message content]
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize() + 4);
+
+    // Verify the size prefix
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(encoded.getSize());
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForEmptyMessage() {
+    Message message = CODEC.messageBuilder().build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+
+    // Verify size matches actual encoded data (ByteBuf now includes 4-byte size prefix)
+    encoded.writeTo(buf);
+
+    // ByteBuf contains: [4-byte size] + [message content]
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize() + 4);
+
+    // Verify the size prefix
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(encoded.getSize());
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForBasicTypes() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .applicationProperties()
+            .entry("string-prop", "test-string")
+            .entry("int-prop", 42)
+            .entry("long-prop", 123456789L)
+            .entry("boolean-prop", true)
+            .entry("double-prop", 3.14159)
+            .messageBuilder()
+            .addData("Basic types test".getBytes())
+            .build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+
+    // Verify size matches actual encoded data (ByteBuf now includes 4-byte size prefix)
+    encoded.writeTo(buf);
+
+    // ByteBuf contains: [4-byte size] + [message content]
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize() + 4);
+
+    // Verify the size prefix
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(encoded.getSize());
+  }
+
+  @Test
+  void outputStreamWritingShouldProduceCorrectSize() throws IOException {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId("test-message-id")
+            .messageBuilder()
+            .addData("Test data for OutputStream".getBytes())
+            .build();
+
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+
+    // Write to OutputStream
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    encoded.writeTo(outputStream);
+    byte[] streamData = outputStream.toByteArray();
+
+    // The first 4 bytes are the size prefix, rest is the message data
+    int sizeFromStream =
+        ((streamData[0] & 0xFF) << 24)
+            | ((streamData[1] & 0xFF) << 16)
+            | ((streamData[2] & 0xFF) << 8)
+            | (streamData[3] & 0xFF);
+
+    assertThat(sizeFromStream).isEqualTo(encoded.getSize());
+    assertThat(streamData.length).isEqualTo(4 + encoded.getSize());
+
+    // Verify ByteBuf output matches OutputStream output (both now include size prefix)
+    encoded.writeTo(buf);
+    byte[] bufData = new byte[buf.readableBytes()];
+    buf.readBytes(bufData);
+
+    // Both OutputStream and ByteBuf should produce identical output now
+    assertThat(bufData).isEqualTo(streamData);
+  }
+
+  @Test
+  void sizeShouldBeAvailableImmediately() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId("immediate-size-test")
+            .messageBuilder()
+            .addData("Size should be available without encoding".getBytes())
+            .build();
+
+    // Size should be available immediately after construction
+    Codec.EncodedMessage encoded = new StreamingEncodedMessage(message);
+    int size = encoded.getSize();
+
+    assertThat(size).isGreaterThan(0);
+
+    // Verify it matches actual encoding (ByteBuf now includes 4-byte size prefix)
+    encoded.writeTo(buf);
+    assertThat(buf.readableBytes()).isEqualTo(size + 4);
+
+    // Verify the size prefix matches
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(size);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSmallApplicationProperties() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .applicationProperties()
+            .entry("k", "v")
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForLargeApplicationProperties() {
+    MessageBuilder.ApplicationPropertiesBuilder appProps =
+        CODEC.messageBuilder().applicationProperties();
+    for (int i = 0; i < 50; i++) {
+      appProps.entry("key-with-long-name-" + i, "value-with-long-content-" + i);
+    }
+    Message message = appProps.messageBuilder().addData("payload".getBytes()).build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSmallMessageAnnotations() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("a", "b")
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForLargeMessageAnnotations() {
+    MessageBuilder.MessageAnnotationsBuilder annotations =
+        CODEC.messageBuilder().messageAnnotations();
+    for (int i = 0; i < 50; i++) {
+      annotations.entry("annotation-key-" + i, "annotation-value-" + i);
+    }
+    Message message = annotations.messageBuilder().addData("payload".getBytes()).build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSmallNestedList() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("list", List.of("a", "b"))
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForLargeNestedList() {
+    List<String> largeList =
+        IntStream.range(0, 50)
+            .mapToObj(i -> "element-with-some-content-" + i)
+            .collect(java.util.stream.Collectors.toList());
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("large-list", largeList)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSmallNestedMap() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("map", Map.of("k1", "v1"))
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForLargeNestedMap() {
+    Map<String, Object> largeMap = new LinkedHashMap<>();
+    for (int i = 0; i < 50; i++) {
+      largeMap.put("map-key-" + i, "map-value-" + i);
+    }
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entry("large-map", largeMap)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSmallArray() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entryArray("arr", new String[] {"a", "b"})
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForLargeArray() {
+    String[] largeArray =
+        IntStream.range(0, 50).mapToObj(i -> "element-" + i).toArray(String[]::new);
+    Message message =
+        CODEC
+            .messageBuilder()
+            .messageAnnotations()
+            .entryArray("large-arr", largeArray)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForSmallProperties() {
+    Message message =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(1L)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForLargeProperties() {
+    String longString = "x".repeat(300);
+    Message message =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(longString)
+            .to(longString)
+            .subject(longString)
+            .replyTo(longString)
+            .correlationId(longString)
+            .groupId(longString)
+            .replyToGroupId(longString)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  private void assertSizeMatchesEncoding(Message message) {
+    Codec.EncodedMessage encoded = CODEC.encode(message);
+    encoded.writeTo(buf);
+    assertThat(buf.readableBytes()).isEqualTo(encoded.getSize() + 4);
+    int sizeFromBuf = buf.readInt();
+    assertThat(sizeFromBuf).isEqualTo(encoded.getSize());
+  }
+}

--- a/src/test/java/com/rabbitmq/stream/codec/StreamingEncodedMessageTest.java
+++ b/src/test/java/com/rabbitmq/stream/codec/StreamingEncodedMessageTest.java
@@ -435,6 +435,52 @@ public class StreamingEncodedMessageTest {
     assertSizeMatchesEncoding(message);
   }
 
+  @Test
+  void sizeCalculationShouldBeExactForMultiByteUtf8Strings() {
+    // 2-byte UTF-8 at the STR8/STR32 boundary
+    String twoByteStr = "\u00E9".repeat(128); // 256 bytes, forces STR32
+    String str8Boundary = "\u00E9".repeat(127) + "x"; // 255 bytes, stays in STR8
+    // 3-byte UTF-8
+    String threeByteStr = "\u4E00".repeat(86); // 258 bytes
+    // 4-byte UTF-8
+    String fourByteStr = new String(Character.toChars(0x1F600)).repeat(64); // 256 bytes
+
+    Message message =
+        CODEC
+            .messageBuilder()
+            .applicationProperties()
+            .entry("two-byte", twoByteStr)
+            .entry("str8-boundary", str8Boundary)
+            .entry("three-byte", threeByteStr)
+            .entry("four-byte", fourByteStr)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
+  @Test
+  void sizeCalculationShouldBeExactForMultiByteUtf8Properties() {
+    String twoByteStr = "\u00E9".repeat(128);
+    String threeByteStr = "\u4E00".repeat(86);
+
+    Message message =
+        CODEC
+            .messageBuilder()
+            .properties()
+            .messageId(twoByteStr)
+            .to(threeByteStr)
+            .subject(twoByteStr)
+            .correlationId(threeByteStr)
+            .groupId(twoByteStr)
+            .messageBuilder()
+            .addData("x".getBytes())
+            .build();
+
+    assertSizeMatchesEncoding(message);
+  }
+
   private void assertSizeMatchesEncoding(Message message) {
     Codec.EncodedMessage encoded = CODEC.encode(message);
     encoded.writeTo(buf);

--- a/src/test/java/com/rabbitmq/stream/impl/Amqp10InteroperabilityTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/Amqp10InteroperabilityTest.java
@@ -21,7 +21,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.rabbitmq.stream.Codec;
 import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.OffsetSpecification;
-import com.rabbitmq.stream.codec.QpidProtonCodec;
 import com.rabbitmq.stream.codec.SwiftMqCodec;
 import com.rabbitmq.stream.impl.Client.ClientParameters;
 import com.rabbitmq.stream.impl.TestUtils.BrokerVersion;
@@ -52,9 +51,6 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
-import org.assertj.core.api.InstanceOfAssertFactories;
-import org.assertj.core.api.InstanceOfAssertFactory;
-import org.assertj.core.api.ObjectAssert;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -66,13 +62,6 @@ public class Amqp10InteroperabilityTest {
   ClientFactory cf;
   Connection connection;
   Session session;
-
-  private static InstanceOfAssertFactory<
-          org.apache.qpid.proton.amqp.messaging.AmqpValue,
-          ObjectAssert<org.apache.qpid.proton.amqp.messaging.AmqpValue>>
-      qpidAmqpValue() {
-    return InstanceOfAssertFactories.type(org.apache.qpid.proton.amqp.messaging.AmqpValue.class);
-  }
 
   @BeforeEach
   void init() throws Exception {
@@ -141,9 +130,11 @@ public class Amqp10InteroperabilityTest {
 
     Message msg = consumeMessage();
     assertThatThrownBy(() -> msg.getBodyAsBinary()).isInstanceOf(IllegalStateException.class);
-    assertThat(msg.getBody())
-        .asInstanceOf(qpidAmqpValue())
-        .matches(v -> v.getValue().equals("hello"));
+    assertThat(msg.getBody()).asString().contains("hello");
+    //
+    //    assertThat(msg.getBody())
+    //        .asInstanceOf(qpidAmqpValue())
+    //        .matches(v -> v.getValue().equals("hello"));
   }
 
   @Test
@@ -185,18 +176,14 @@ public class Amqp10InteroperabilityTest {
     p.close();
 
     Message msg = consumeMessage();
-    assertThat(msg.getBody())
-        .isInstanceOf(org.apache.qpid.proton.amqp.messaging.AmqpSequence.class);
-    org.apache.qpid.proton.amqp.messaging.AmqpSequence body =
-        (org.apache.qpid.proton.amqp.messaging.AmqpSequence) msg.getBody();
-    // SwiftMQ does not seem to read any AMQP sequences, and QPid reads only the first one
+    assertThat(msg.getBody()).isInstanceOf(List.class);
     @SuppressWarnings("unchecked")
-    List<String> bodyValue = body.getValue();
+    List<String> bodyValue = (List<String>) msg.getBody();
     assertThat(bodyValue).containsExactly("hello", "brave");
   }
 
   Message consumeMessage() {
-    return consumeMessage(new QpidProtonCodec());
+    return consumeMessage(Codecs.DEFAULT);
   }
 
   Message consumeMessage(Codec codec) {

--- a/src/test/java/com/rabbitmq/stream/impl/AmqpInteroperabilityTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/AmqpInteroperabilityTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -36,6 +36,7 @@ import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageBuilder;
 import com.rabbitmq.stream.OffsetSpecification;
 import com.rabbitmq.stream.amqp.UnsignedByte;
+import com.rabbitmq.stream.codec.InternalCodec;
 import com.rabbitmq.stream.codec.QpidProtonCodec;
 import com.rabbitmq.stream.codec.SwiftMqCodec;
 import com.rabbitmq.stream.impl.Client.ClientParameters;
@@ -74,7 +75,7 @@ public class AmqpInteroperabilityTest {
   String brokerVersion;
 
   static Stream<Codec> codecs() {
-    return Stream.of(new QpidProtonCodec(), new SwiftMqCodec());
+    return Stream.of(new QpidProtonCodec(), new SwiftMqCodec(), new InternalCodec());
   }
 
   private static HeaderTestConfiguration htc(

--- a/src/test/java/com/rabbitmq/stream/impl/ClientTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ClientTest.java
@@ -37,7 +37,7 @@ import com.rabbitmq.stream.MessageBuilder;
 import com.rabbitmq.stream.OffsetSpecification;
 import com.rabbitmq.stream.Properties;
 import com.rabbitmq.stream.StreamException;
-import com.rabbitmq.stream.codec.QpidProtonCodec;
+import com.rabbitmq.stream.codec.InternalCodec;
 import com.rabbitmq.stream.codec.SimpleCodec;
 import com.rabbitmq.stream.codec.SwiftMqCodec;
 import com.rabbitmq.stream.impl.Client.ClientParameters;
@@ -374,8 +374,8 @@ public class ClientTest {
   }
 
   @Test
-  void publishConsumeComplexMessageWithMessageBuilderAndQpidProtonCodec() {
-    Codec codec = new QpidProtonCodec();
+  void publishConsumeComplexMessageWithMessageBuilderAndInternalCodec() {
+    Codec codec = new InternalCodec();
     Client publisher = cf.get(new Client.ClientParameters().codec(codec));
     publishConsumeComplexMessage(
         publisher,

--- a/src/test/java/com/rabbitmq/stream/impl/ClientTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ClientTest.java
@@ -1038,8 +1038,7 @@ public class ClientTest {
             bb.writeShort(msg.filterValue.length());
             bb.writeBytes(msg.filterValue.getBytes(StandardCharsets.UTF_8));
             Codec.EncodedMessage messageToPublish = msg.encodedMessage;
-            bb.writeInt(messageToPublish.getSize());
-            bb.writeBytes(messageToPublish.getData(), 0, messageToPublish.getSize());
+            messageToPublish.writeTo(bb);
             return 1;
           }
 

--- a/src/test/java/com/rabbitmq/stream/impl/CompressionCodecsTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/CompressionCodecsTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -17,6 +17,7 @@ package com.rabbitmq.stream.impl;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.rabbitmq.stream.Codec.EncodedMessage;
+import com.rabbitmq.stream.codec.ByteArrayEncodedMessage;
 import com.rabbitmq.stream.compression.CompressionCodec;
 import com.rabbitmq.stream.compression.CompressionUtils.CommonsCompressGzipCompressionCodec;
 import com.rabbitmq.stream.compression.CompressionUtils.CommonsCompressLz4CompressionCodec;
@@ -80,7 +81,7 @@ public class CompressionCodecsTest {
         .forEach(
             i -> {
               byte[] body = ("message " + i).getBytes(StandardCharsets.UTF_8);
-              EncodedMessage encodedMessage = new EncodedMessage(body.length, body);
+              EncodedMessage encodedMessage = new ByteArrayEncodedMessage(body.length, body);
               encodedMessageBatch.add(encodedMessage);
               encodedMessages.add(encodedMessage);
             });
@@ -110,7 +111,7 @@ public class CompressionCodecsTest {
       int size = outBb.readInt();
       byte[] msg = new byte[size];
       outBb.readBytes(msg);
-      decompressedMessages.add(new EncodedMessage(size, msg));
+      decompressedMessages.add(new ByteArrayEncodedMessage(size, msg));
     }
 
     assertThat(decompressedMessages).hasSameSizeAs(encodedMessages);
@@ -120,7 +121,8 @@ public class CompressionCodecsTest {
               EncodedMessage originalMessage = encodedMessages.get(i);
               EncodedMessage decompressedMessage = decompressedMessages.get(i);
               assertThat(decompressedMessage.getSize()).isEqualTo(originalMessage.getSize());
-              assertThat(decompressedMessage.getData()).isEqualTo(originalMessage.getData());
+              assertThat(TestUtils.encodedMessageByteBuf(decompressedMessage))
+                  .isEqualTo(TestUtils.encodedMessageByteBuf(originalMessage));
             });
 
     destinationBb.release();

--- a/src/test/java/com/rabbitmq/stream/impl/DeliveryTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/DeliveryTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -42,7 +42,7 @@ public class DeliveryTest {
         }
 
         @Override
-        public Message decode(byte[] data) {
+        public Message decode(ByteBuf buf, int length) {
           return null;
         }
 

--- a/src/test/java/com/rabbitmq/stream/impl/FilteringTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/FilteringTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -202,6 +202,7 @@ public class FilteringTest {
                   .builder()
                   .messageHandler(
                       (ctx, msg) -> {
+                        System.out.println(msg.getProperties().getGroupId());
                         receivedFilterValues.add(
                             msg.getProperties().getGroupId() == null
                                 ? "null"

--- a/src/test/java/com/rabbitmq/stream/impl/FrameTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/FrameTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -21,10 +21,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.rabbitmq.stream.Codec;
 import com.rabbitmq.stream.Constants;
 import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.Properties;
+import com.rabbitmq.stream.codec.ByteArrayEncodedMessage;
 import io.netty.buffer.ByteBuf;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
@@ -157,7 +157,7 @@ public class FrameTest {
                 channel,
                 b(1),
                 test.sizes.stream()
-                    .map(size -> new Codec.EncodedMessage(size, new byte[size]))
+                    .map(size -> new ByteArrayEncodedMessage(size, new byte[size]))
                     .collect(Collectors.toList()),
                 Client.OUTBOUND_MESSAGE_WRITE_CALLBACK,
                 publishSequenceFunction);

--- a/src/test/java/com/rabbitmq/stream/impl/StreamConsumerTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamConsumerTest.java
@@ -1172,8 +1172,8 @@ public class StreamConsumerTest {
       env.consumerBuilder().offset(OffsetSpecification.first()).stream(stream)
           .messageHandler(
               (context, message) -> {
-                sync.down();
                 msg.set(message);
+                sync.down();
               })
           .build();
       assertThat(sync).completes();

--- a/src/test/java/com/rabbitmq/stream/impl/TestUtils.java
+++ b/src/test/java/com/rabbitmq/stream/impl/TestUtils.java
@@ -32,6 +32,7 @@ import com.rabbitmq.client.Connection;
 import com.rabbitmq.client.ConnectionFactory;
 import com.rabbitmq.stream.Address;
 import com.rabbitmq.stream.Cli;
+import com.rabbitmq.stream.Codec;
 import com.rabbitmq.stream.Constants;
 import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageBuilder;
@@ -40,6 +41,8 @@ import com.rabbitmq.stream.impl.Client.Broker;
 import com.rabbitmq.stream.impl.Client.ClientParameters;
 import com.rabbitmq.stream.impl.Client.Response;
 import com.rabbitmq.stream.impl.Client.StreamMetadata;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.EventLoopGroup;
 import io.vavr.Tuple2;
 import java.io.IOException;
@@ -1236,5 +1239,12 @@ public final class TestUtils {
     int port = socket.getLocalPort();
     socket.close();
     return port;
+  }
+
+  public static ByteBuf encodedMessageByteBuf(Codec.EncodedMessage encoded) {
+    ByteBuf buf = Unpooled.buffer();
+    encoded.writeTo(buf);
+    buf.skipBytes(Integer.BYTES);
+    return buf;
   }
 }

--- a/src/test/java/com/rabbitmq/stream/observation/micrometer/MicrometerObservationCollectorTest.java
+++ b/src/test/java/com/rabbitmq/stream/observation/micrometer/MicrometerObservationCollectorTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2007-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2007-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -25,7 +25,7 @@ import com.rabbitmq.stream.Environment;
 import com.rabbitmq.stream.EnvironmentBuilder;
 import com.rabbitmq.stream.ObservationCollector;
 import com.rabbitmq.stream.Producer;
-import com.rabbitmq.stream.codec.QpidProtonCodec;
+import com.rabbitmq.stream.codec.InternalCodec;
 import com.rabbitmq.stream.codec.SwiftMqCodec;
 import com.rabbitmq.stream.impl.TestUtils;
 import io.micrometer.tracing.test.SampleTestRunner;
@@ -117,8 +117,7 @@ public class MicrometerObservationCollectorTest {
 
     @Override
     public SampleTestRunnerConsumer yourCode() {
-      return (buildingBlocks, meterRegistry) ->
-          publishConsume(new QpidProtonCodec(), buildingBlocks);
+      return (buildingBlocks, meterRegistry) -> publishConsume(new InternalCodec(), buildingBlocks);
     }
   }
 


### PR DESCRIPTION
This avoids depending on external dependencies and allows stream-specific optimizations.