### PR TITLE
Fix NPE from `ConsumersCoordinator` when `Client.subscribe` returns null

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ConsumersCoordinator.java
@@ -1174,6 +1174,16 @@ final class ConsumersCoordinator implements AutoCloseable {
                   "Subscribe request for consumer %d on stream '%s'",
                   tracker.consumer.id(),
                   tracker.stream);
+          if (subscribeResponse == null) {
+            // The subscribe call returned no response: the connection was torn down
+            // between the request being written and the response being read, or the
+            // stream was deleted concurrently.
+            if (!client.isOpen()) {
+              throw new ConnectionStreamException(
+                  "Connection closed during subscribe on stream '" + tracker.stream + "'");
+            }
+            throw new StreamDoesNotExistException(tracker.stream);
+          }
           if (!subscribeResponse.isOk()) {
             String message =
                 "Subscription to stream "

--- a/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ConsumersCoordinatorTest.java
@@ -431,6 +431,34 @@ public class ConsumersCoordinatorTest {
   }
 
   @Test
+  void subscribeShouldThrowStreamExceptionWhenClientSubscribeReturnsNull() {
+    when(locator.metadata("stream")).thenReturn(metadata(null, replicas()));
+    when(clientFactory.client(any())).thenReturn(client);
+    when(client.subscribe(
+            subscriptionIdCaptor.capture(),
+            anyString(),
+            any(OffsetSpecification.class),
+            anyInt(),
+            anyMap()))
+        .thenReturn(null);
+
+    assertThatThrownBy(
+            () ->
+                coordinator.subscribe(
+                    consumer,
+                    "stream",
+                    OffsetSpecification.first(),
+                    null,
+                    NO_OP_SUBSCRIPTION_LISTENER,
+                    NO_OP_TRACKING_CLOSING_CALLBACK,
+                    (offset, message) -> {},
+                    Collections.emptyMap(),
+                    flowStrategy()))
+        .isInstanceOf(StreamException.class);
+    assertThat(MonitoringTestUtils.extract(coordinator).isEmpty()).isTrue();
+  }
+
+  @Test
   void subscribeShouldThrowExceptionWhenMetadataResponseIsNotOk() {
     when(locator.metadata("stream"))
         .thenReturn(metadata("stream", null, null, Constants.RESPONSE_CODE_ACCESS_REFUSED));


### PR DESCRIPTION
Check if `client.subscribe` returns non `null` before dereferencing. Throw structured exception if the stream no longer exists or the connection was closed

Fixes https://github.com/rabbitmq/rabbitmq-stream-java-client/issues/984