### PR TITLE
Do not use reflection to duplicate ClientParameters and consumer builder

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -115,7 +115,6 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -2832,18 +2831,41 @@ public class Client implements AutoCloseable {
 
     public ClientParameters duplicate() {
       ClientParameters duplicate = new ClientParameters();
-      for (Field field : ClientParameters.class.getDeclaredFields()) {
-        field.setAccessible(true);
-        try {
-          Object value = field.get(this);
-          if (value instanceof Map) {
-            value = new ConcurrentHashMap<>((Map<?, ?>) value);
-          }
-          field.set(duplicate, value);
-        } catch (IllegalAccessException e) {
-          throw new StreamException("Error while duplicating client parameters", e);
-        }
-      }
+
+      // Copy clientProperties map
+      duplicate.clientProperties.putAll(this.clientProperties);
+
+      // Copy all other fields
+      duplicate.eventLoopGroup = this.eventLoopGroup;
+      duplicate.codec = this.codec;
+      duplicate.host = this.host;
+      duplicate.port = this.port;
+      duplicate.compressionCodecFactory = this.compressionCodecFactory;
+      duplicate.virtualHost = this.virtualHost;
+      duplicate.requestedHeartbeat = this.requestedHeartbeat;
+      duplicate.requestedMaxFrameSize = this.requestedMaxFrameSize;
+      duplicate.publishConfirmListener = this.publishConfirmListener;
+      duplicate.publishErrorListener = this.publishErrorListener;
+      duplicate.chunkListener = this.chunkListener;
+      duplicate.messageListener = this.messageListener;
+      duplicate.messageIgnoredListener = this.messageIgnoredListener;
+      duplicate.metadataListener = this.metadataListener;
+      duplicate.creditNotification = this.creditNotification;
+      duplicate.consumerUpdateListener = this.consumerUpdateListener;
+      duplicate.shutdownListener = this.shutdownListener;
+      duplicate.saslConfiguration = this.saslConfiguration;
+      duplicate.credentialsProvider = this.credentialsProvider;
+      duplicate.credentialsManager = this.credentialsManager;
+      duplicate.chunkChecksum = this.chunkChecksum;
+      duplicate.metricsCollector = this.metricsCollector;
+      duplicate.sslContext = this.sslContext;
+      duplicate.byteBufAllocator = this.byteBufAllocator;
+      duplicate.rpcTimeout = this.rpcTimeout;
+      duplicate.channelCustomizer = this.channelCustomizer;
+      duplicate.bootstrapCustomizer = this.bootstrapCustomizer;
+      duplicate.dispatchingExecutorServiceFactory = this.dispatchingExecutorServiceFactory;
+      duplicate.executorServiceFactory = this.executorServiceFactory;
+
       return duplicate;
     }
   }

--- a/src/main/java/com/rabbitmq/stream/impl/StreamConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamConsumerBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -25,11 +25,8 @@ import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageHandler;
 import com.rabbitmq.stream.OffsetSpecification;
 import com.rabbitmq.stream.Resource;
-import com.rabbitmq.stream.StreamException;
 import com.rabbitmq.stream.SubscriptionListener;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -277,17 +274,27 @@ class StreamConsumerBuilder implements ConsumerBuilder {
 
   StreamConsumerBuilder duplicate() {
     StreamConsumerBuilder duplicate = new StreamConsumerBuilder(this.environment);
-    for (Field field : StreamConsumerBuilder.class.getDeclaredFields()) {
-      if (Modifier.isStatic(field.getModifiers())) {
-        continue;
-      }
-      field.setAccessible(true);
-      try {
-        field.set(duplicate, field.get(this));
-      } catch (IllegalAccessException e) {
-        throw new StreamException("Error while duplicating stream producer builder", e);
-      }
-    }
+
+    // Copy subscriptionProperties map
+    duplicate.subscriptionProperties.putAll(this.subscriptionProperties);
+
+    // Copy all other fields
+    duplicate.stream = this.stream;
+    duplicate.superStream = this.superStream;
+    duplicate.offsetSpecification = this.offsetSpecification;
+    duplicate.messageHandler = this.messageHandler;
+    duplicate.name = this.name;
+    duplicate.autoTrackingStrategy = this.autoTrackingStrategy;
+    duplicate.manualTrackingStrategy = this.manualTrackingStrategy;
+    duplicate.noTrackingStrategy = this.noTrackingStrategy;
+    duplicate.lazyInit = this.lazyInit;
+    duplicate.subscriptionListener = this.subscriptionListener;
+    // Note: flowConfiguration and filterConfiguration are final fields initialized in constructor
+    // and don't need explicit copying since they are instance-specific
+    duplicate.consumerUpdateListener = this.consumerUpdateListener;
+    // Copy listeners list
+    duplicate.listeners.addAll(this.listeners);
+
     return duplicate;
   }
 


### PR DESCRIPTION
This avoids some warnings in recent versions of Java.

References rabbitmq/rabbitmq-stream-perf-test#411