### PR TITLE
Do not use reflection to duplicate ClientParameters and consumer builder

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -115,7 +115,6 @@ import io.netty.handler.timeout.IdleStateHandler;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
 import java.io.OutputStream;
-import java.lang.reflect.Field;
 import java.net.ConnectException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
@@ -2578,6 +2577,7 @@ public class Client implements AutoCloseable {
   }
 
   public static class ClientParameters {
+    // IMPORTANT: When adding new fields, make sure to update the copy constructor method below!
 
     private final Map<String, String> clientProperties = new ConcurrentHashMap<>();
     EventLoopGroup eventLoopGroup;
@@ -2621,6 +2621,44 @@ public class Client implements AutoCloseable {
     private ExecutorServiceFactory dispatchingExecutorServiceFactory;
     // for other server frames
     private ExecutorServiceFactory executorServiceFactory;
+
+    public ClientParameters() {}
+
+    public ClientParameters(ClientParameters other) {
+      // Copy clientProperties map
+      this.clientProperties.putAll(other.clientProperties);
+
+      // Copy all other fields
+      this.eventLoopGroup = other.eventLoopGroup;
+      this.codec = other.codec;
+      this.host = other.host;
+      this.port = other.port;
+      this.compressionCodecFactory = other.compressionCodecFactory;
+      this.virtualHost = other.virtualHost;
+      this.requestedHeartbeat = other.requestedHeartbeat;
+      this.requestedMaxFrameSize = other.requestedMaxFrameSize;
+      this.publishConfirmListener = other.publishConfirmListener;
+      this.publishErrorListener = other.publishErrorListener;
+      this.chunkListener = other.chunkListener;
+      this.messageListener = other.messageListener;
+      this.messageIgnoredListener = other.messageIgnoredListener;
+      this.metadataListener = other.metadataListener;
+      this.creditNotification = other.creditNotification;
+      this.consumerUpdateListener = other.consumerUpdateListener;
+      this.shutdownListener = other.shutdownListener;
+      this.saslConfiguration = other.saslConfiguration;
+      this.credentialsProvider = other.credentialsProvider;
+      this.credentialsManager = other.credentialsManager;
+      this.chunkChecksum = other.chunkChecksum;
+      this.metricsCollector = other.metricsCollector;
+      this.sslContext = other.sslContext;
+      this.byteBufAllocator = other.byteBufAllocator;
+      this.rpcTimeout = other.rpcTimeout;
+      this.channelCustomizer = other.channelCustomizer;
+      this.bootstrapCustomizer = other.bootstrapCustomizer;
+      this.dispatchingExecutorServiceFactory = other.dispatchingExecutorServiceFactory;
+      this.executorServiceFactory = other.executorServiceFactory;
+    }
 
     public ClientParameters host(String host) {
       this.host = host;
@@ -2831,20 +2869,7 @@ public class Client implements AutoCloseable {
     }
 
     public ClientParameters duplicate() {
-      ClientParameters duplicate = new ClientParameters();
-      for (Field field : ClientParameters.class.getDeclaredFields()) {
-        field.setAccessible(true);
-        try {
-          Object value = field.get(this);
-          if (value instanceof Map) {
-            value = new ConcurrentHashMap<>((Map<?, ?>) value);
-          }
-          field.set(duplicate, value);
-        } catch (IllegalAccessException e) {
-          throw new StreamException("Error while duplicating client parameters", e);
-        }
-      }
-      return duplicate;
+      return new ClientParameters(this);
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/StreamConsumerBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamConsumerBuilder.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -25,11 +25,8 @@ import com.rabbitmq.stream.Message;
 import com.rabbitmq.stream.MessageHandler;
 import com.rabbitmq.stream.OffsetSpecification;
 import com.rabbitmq.stream.Resource;
-import com.rabbitmq.stream.StreamException;
 import com.rabbitmq.stream.SubscriptionListener;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -62,6 +59,31 @@ class StreamConsumerBuilder implements ConsumerBuilder {
 
   public StreamConsumerBuilder(StreamEnvironment environment) {
     this.environment = environment;
+  }
+
+  public StreamConsumerBuilder(StreamConsumerBuilder other) {
+    // Copy environment reference
+    this.environment = other.environment;
+
+    // Copy subscriptionProperties map
+    this.subscriptionProperties.putAll(other.subscriptionProperties);
+
+    // Copy all other fields
+    this.stream = other.stream;
+    this.superStream = other.superStream;
+    this.offsetSpecification = other.offsetSpecification;
+    this.messageHandler = other.messageHandler;
+    this.name = other.name;
+    this.autoTrackingStrategy = other.autoTrackingStrategy;
+    this.manualTrackingStrategy = other.manualTrackingStrategy;
+    this.noTrackingStrategy = other.noTrackingStrategy;
+    this.lazyInit = other.lazyInit;
+    this.subscriptionListener = other.subscriptionListener;
+    // Note: flowConfiguration is initialized in field declaration, copy its strategy
+    this.flowConfiguration.strategy(other.flowConfiguration.getStrategy());
+    this.consumerUpdateListener = other.consumerUpdateListener;
+    this.filterConfiguration = other.filterConfiguration;
+    this.listeners.addAll(other.listeners);
   }
 
   @Override
@@ -276,19 +298,7 @@ class StreamConsumerBuilder implements ConsumerBuilder {
   }
 
   StreamConsumerBuilder duplicate() {
-    StreamConsumerBuilder duplicate = new StreamConsumerBuilder(this.environment);
-    for (Field field : StreamConsumerBuilder.class.getDeclaredFields()) {
-      if (Modifier.isStatic(field.getModifiers())) {
-        continue;
-      }
-      field.setAccessible(true);
-      try {
-        field.set(duplicate, field.get(this));
-      } catch (IllegalAccessException e) {
-        throw new StreamException("Error while duplicating stream producer builder", e);
-      }
-    }
-    return duplicate;
+    return new StreamConsumerBuilder(this);
   }
 
   static class TrackingConfiguration {
@@ -475,6 +485,10 @@ class StreamConsumerBuilder implements ConsumerBuilder {
     @Override
     public ConsumerBuilder builder() {
       return this.consumerBuilder;
+    }
+
+    private ConsumerFlowStrategy getStrategy() {
+      return this.strategy;
     }
   }
 

--- a/src/test/java/com/rabbitmq/stream/impl/StreamConsumerBuilderTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamConsumerBuilderTest.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// Copyright (c) 2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -14,35 +14,17 @@
 // info@rabbitmq.com.
 package com.rabbitmq.stream.impl;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.rabbitmq.stream.impl.Client.ClientParameters;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import org.junit.jupiter.api.Test;
 
-public class ClientParametersTest {
-
-  @Test
-  void duplicate() {
-    Client.ClientParameters clientParameters1 =
-        new Client.ClientParameters().host("rabbitmq").port(5556);
-    clientParameters1.clientProperty("connection_name", "producer");
-    ClientParameters clientParameters2 = clientParameters1.duplicate();
-    assertThat(clientParameters2.host()).isEqualTo("rabbitmq");
-    assertThat(clientParameters2.port()).isEqualTo(5556);
-
-    // same as original
-    assertThat(clientParameters2.clientProperties()).containsEntry("connection_name", "producer");
-    // changing the copy should not change the original
-    clientParameters2.clientProperty("connection_name", "consumer");
-    assertThat(clientParameters1.clientProperties()).containsEntry("connection_name", "producer");
-  }
+public class StreamConsumerBuilderTest {
 
   @Test
   void duplicateMethodHandlesAllFields() {
-    Field[] allFields = ClientParameters.class.getDeclaredFields();
+    Field[] allFields = StreamConsumerBuilder.class.getDeclaredFields();
     int nonStaticFields = 0;
     for (Field field : allFields) {
       if (!Modifier.isStatic(field.getModifiers())) {
@@ -51,7 +33,7 @@ public class ClientParametersTest {
     }
 
     assertEquals(
-        30,
+        16,
         nonStaticFields,
         "If this fails, update the copy constructor method to handle the new field(s)");
   }


### PR DESCRIPTION
This avoids some warnings in recent versions of Java.

References rabbitmq/rabbitmq-stream-perf-test#411