### PR TITLE
Make sure RPC response is not null before returning it

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -665,8 +665,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<SaslAuthenticateResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -690,13 +689,13 @@ public class Client implements AutoCloseable {
       OutstandingRequest<OpenResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      if (!request.response.get().isOk()) {
+      OpenResponse response = request.blockAndGet();
+      if (!response.isOk()) {
         throw new StreamException(
             "Unexpected response code when connecting to virtual host: "
-                + formatConstant(request.response.get().getResponseCode()));
+                + formatConstant(response.getResponseCode()));
       }
-      return request.response.get().connectionProperties;
+      return response.connectionProperties;
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -732,14 +731,13 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      if (!request.response.get().isOk()) {
+      Response response = request.blockAndGet();
+      if (!response.isOk()) {
         LOGGER.warn(
             "Unexpected response code when closing: {}",
-            formatConstant(request.response.get().getResponseCode()));
+            formatConstant(response.getResponseCode()));
         throw new StreamException(
-            "Unexpected response code when closing: "
-                + formatConstant(request.response.get().getResponseCode()));
+            "Unexpected response code when closing: " + formatConstant(response.getResponseCode()));
       }
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
@@ -762,8 +760,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<List<String>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -792,8 +789,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -843,8 +839,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -869,8 +864,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -953,8 +947,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -984,8 +977,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Map<String, StreamMetadata>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1023,8 +1015,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1048,8 +1039,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1386,8 +1376,7 @@ public class Client implements AutoCloseable {
             new SubscriptionOffset(subscriptionId, offsetSpecification.getOffset()));
       }
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1443,8 +1432,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<QueryOffsetResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1522,8 +1510,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<ResolveOffsetSpecResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1560,8 +1547,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<QueryPublisherSequenceResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      QueryPublisherSequenceResponse response = request.response.get();
+      QueryPublisherSequenceResponse response = request.blockAndGet();
       if (!response.isOk()) {
         LOGGER.info(
             "Query publisher sequence failed with code {}",
@@ -1594,8 +1580,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1762,8 +1747,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<List<String>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1795,8 +1779,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<List<String>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1827,8 +1810,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<List<FrameHandlerInfo>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -1856,8 +1838,7 @@ public class Client implements AutoCloseable {
       OutstandingRequest<StreamStatsResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
-      request.block();
-      return request.response.get();
+      return request.blockAndGet();
     } catch (StreamException e) {
       this.handleRpcError(correlationId, e);
       throw e;
@@ -2919,6 +2900,22 @@ public class Client implements AutoCloseable {
 
     void countDown() {
       this.latch.countDown();
+    }
+
+    T blockAndGet() {
+      block();
+      if (response.get() != null) {
+        return response.get();
+      } else {
+        Throwable t = error.get();
+        if (t instanceof RuntimeException) {
+          throw (RuntimeException) t;
+        } else if (t != null) {
+          throw new StreamException(t);
+        } else {
+          throw new StreamException("Error during RPC operation, no response");
+        }
+      }
     }
   }
 

--- a/src/main/java/com/rabbitmq/stream/impl/ConnectionStreamException.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ConnectionStreamException.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Broadcom. All Rights Reserved.
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
 // The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 //
 // This software, the RabbitMQ Stream Java client library, is dual-licensed under the
@@ -18,11 +18,11 @@ import com.rabbitmq.stream.StreamException;
 
 class ConnectionStreamException extends StreamException {
 
-  public ConnectionStreamException(String message) {
+  ConnectionStreamException(String message) {
     super(message);
   }
 
-  public ConnectionStreamException(String message, Throwable cause) {
+  ConnectionStreamException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/src/main/java/com/rabbitmq/stream/impl/StreamConsumer.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamConsumer.java
@@ -57,20 +57,10 @@ import org.slf4j.LoggerFactory;
 
 final class StreamConsumer extends ResourceBase implements Consumer {
 
-  private static final AtomicLong ID_SEQUENCE = new AtomicLong(0);
   static final String COMPONENT_SUBSCRIPTION = "subscription";
   static final String COMPONENT_TRACKING = "tracking";
-
+  private static final AtomicLong ID_SEQUENCE = new AtomicLong(0);
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamConsumer.class);
-
-  private static String[] componentIds(TrackingConfiguration trackingConfiguration) {
-    if (trackingConfiguration.enabled()) {
-      return new String[] {COMPONENT_SUBSCRIPTION, COMPONENT_TRACKING};
-    } else {
-      return new String[] {COMPONENT_SUBSCRIPTION};
-    }
-  }
-
   private final long id;
   private final AtomicBoolean closed = new AtomicBoolean(false);
   private final String name;
@@ -79,15 +69,15 @@ final class StreamConsumer extends ResourceBase implements Consumer {
   private final LongConsumer trackingCallback;
   private final Runnable initCallback;
   private final ConsumerUpdateListener consumerUpdateListener;
+  private final AtomicBoolean nothingStoredYet = new AtomicBoolean(true);
+  private final boolean sac;
+  private final OffsetSpecification initialOffsetSpecification;
+  private final Lock lock = new ReentrantLock();
   private volatile Runnable closingCallback;
   private volatile Client trackingClient;
   private volatile Client subscriptionClient;
   private volatile long lastRequestedStoredOffset = 0;
-  private final AtomicBoolean nothingStoredYet = new AtomicBoolean(true);
   private volatile boolean sacActive;
-  private final boolean sac;
-  private final OffsetSpecification initialOffsetSpecification;
-  private final Lock lock = new ReentrantLock();
 
   StreamConsumer(
       String stream,
@@ -277,6 +267,14 @@ final class StreamConsumer extends ResourceBase implements Consumer {
     }
   }
 
+  private static String[] componentIds(TrackingConfiguration trackingConfiguration) {
+    if (trackingConfiguration.enabled()) {
+      return new String[] {COMPONENT_SUBSCRIPTION, COMPONENT_TRACKING};
+    } else {
+      return new String[] {COMPONENT_SUBSCRIPTION};
+    }
+  }
+
   static OffsetSpecification getStoredOffset(
       StreamConsumer consumer, StreamEnvironment environment, OffsetSpecification fallback) {
     OffsetSpecification result = null;
@@ -415,7 +413,16 @@ final class StreamConsumer extends ResourceBase implements Consumer {
       result = this.consumerUpdateListener.update(context);
       LOGGER.debug("Consumer update listener returned {}", result);
     } catch (Exception e) {
-      LOGGER.warn("Error in consumer update listener", e);
+      Client trackingClient = this.trackingClient;
+      Client subClient = this.subscriptionClient;
+      if (!this.isOpen()
+          || (trackingClient != null && !trackingClient.isOpen())
+          || (subClient != null && !subClient.isOpen())) {
+        // the connections are recovering or even closing, we avoid noise in logs
+        LOGGER.info("Error in consumer update listener: {}", e.getMessage());
+      } else {
+        LOGGER.warn("Error in consumer update listener", e);
+      }
     }
 
     // TODO pause/unpause offset tracking strategy
@@ -423,37 +430,6 @@ final class StreamConsumer extends ResourceBase implements Consumer {
     // pausing/unpausing them would save some resources, but makes the code more complicated
 
     return result;
-  }
-
-  private static class DefaultConsumerUpdateContext implements ConsumerUpdateListener.Context {
-
-    private final StreamConsumer consumer;
-    private final boolean active;
-
-    private DefaultConsumerUpdateContext(StreamConsumer consumer, boolean active) {
-      this.consumer = consumer;
-      this.active = active;
-    }
-
-    @Override
-    public Consumer consumer() {
-      return this.consumer;
-    }
-
-    @Override
-    public String stream() {
-      return this.consumer.stream;
-    }
-
-    @Override
-    public boolean isActive() {
-      return this.active;
-    }
-
-    @Override
-    public String toString() {
-      return "DefaultConsumerUpdateContext{" + "consumer=" + consumer + ", active=" + active + '}';
-    }
   }
 
   boolean isSac() {
@@ -633,6 +609,37 @@ final class StreamConsumer extends ResourceBase implements Consumer {
     if (state() == CLOSED) {
       // will throw the appropriate exception
       checkOpen();
+    }
+  }
+
+  private static class DefaultConsumerUpdateContext implements ConsumerUpdateListener.Context {
+
+    private final StreamConsumer consumer;
+    private final boolean active;
+
+    private DefaultConsumerUpdateContext(StreamConsumer consumer, boolean active) {
+      this.consumer = consumer;
+      this.active = active;
+    }
+
+    @Override
+    public Consumer consumer() {
+      return this.consumer;
+    }
+
+    @Override
+    public String stream() {
+      return this.consumer.stream;
+    }
+
+    @Override
+    public boolean isActive() {
+      return this.active;
+    }
+
+    @Override
+    public String toString() {
+      return "DefaultConsumerUpdateContext{" + "consumer=" + consumer + ", active=" + active + '}';
     }
   }
 }


### PR DESCRIPTION
Null RPC response is not normal, it should trigger an exception.

This could happen if the client was closed while waiting for the response, because the outstanding requests are completed exceptionally, but the response was not checked.