### PR TITLE
Fix UTF-8 string encoding and byte accounting in wire protocol

### DIFF
--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -645,7 +645,7 @@ public class Client implements AutoCloseable {
             + 2
             + 4
             + 2
-            + saslMechanism.getName().length()
+            + stringByteSize(saslMechanism.getName())
             + 4
             + (challengeResponse == null ? 0 : challengeResponse.length);
     int correlationId = nextCorrelationId();
@@ -655,8 +655,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_SASL_AUTHENTICATE));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(saslMechanism.getName().length());
-      bb.writeBytes(saslMechanism.getName().getBytes(CHARSET));
+      writeString(bb, saslMechanism.getName());
       if (challengeResponse == null) {
         bb.writeInt(-1);
       } else {
@@ -676,7 +675,7 @@ public class Client implements AutoCloseable {
   }
 
   private Map<String, String> open(String virtualHost) {
-    int length = 2 + 2 + 4 + 2 + virtualHost.length();
+    int length = 2 + 2 + 4 + 2 + stringByteSize(virtualHost);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -684,8 +683,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_OPEN));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(virtualHost.length());
-      bb.writeBytes(virtualHost.getBytes(CHARSET));
+      writeString(bb, virtualHost);
       OutstandingRequest<OpenResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -717,7 +715,7 @@ public class Client implements AutoCloseable {
   }
 
   private void sendClose(short code, String reason) {
-    int length = 2 + 2 + 4 + 2 + 2 + reason.length();
+    int length = 2 + 2 + 4 + 2 + 2 + stringByteSize(reason);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -726,8 +724,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
       bb.writeShort(code);
-      bb.writeShort(reason.length());
-      bb.writeBytes(reason.getBytes(CHARSET));
+      writeString(bb, reason);
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -775,7 +772,7 @@ public class Client implements AutoCloseable {
   }
 
   public Response create(String stream, Map<String, String> arguments) {
-    int length = 2 + 2 + 4 + 2 + stream.length() + mapSize(arguments);
+    int length = 2 + 2 + 4 + 2 + stringByteSize(stream) + mapSize(arguments);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -783,8 +780,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_CREATE_STREAM));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, stream);
       writeMap(bb, arguments);
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
@@ -820,7 +816,7 @@ public class Client implements AutoCloseable {
             + 2
             + 4
             + 2
-            + superStream.length()
+            + stringByteSize(superStream)
             + collectionSize(partitions)
             + collectionSize(bindingKeys)
             + mapSize(arguments);
@@ -831,8 +827,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_CREATE_SUPER_STREAM));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(superStream.length());
-      bb.writeBytes(superStream.getBytes(CHARSET));
+      writeString(bb, superStream);
       writeCollection(bb, partitions);
       writeCollection(bb, bindingKeys);
       writeMap(bb, arguments);
@@ -851,7 +846,7 @@ public class Client implements AutoCloseable {
 
   Response deleteSuperStream(String superStream) {
     this.superStreamManagementCommandVersionsCheck.run();
-    int length = 2 + 2 + 4 + 2 + superStream.length();
+    int length = 2 + 2 + 4 + 2 + stringByteSize(superStream);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -859,8 +854,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_DELETE_SUPER_STREAM));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(superStream.length());
-      bb.writeBytes(superStream.getBytes(CHARSET));
+      writeString(bb, superStream);
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -875,7 +869,7 @@ public class Client implements AutoCloseable {
   }
 
   private static int collectionSize(Collection<String> elements) {
-    return 4 + elements.stream().mapToInt(v -> 2 + v.length()).sum();
+    return 4 + elements.stream().mapToInt(v -> 2 + stringByteSize(v)).sum();
   }
 
   private static int arraySize(String... elements) {
@@ -885,29 +879,36 @@ public class Client implements AutoCloseable {
   private static int mapSize(Map<String, String> elements) {
     return 4
         + elements.entrySet().stream()
-            .mapToInt(e -> 2 + e.getKey().length() + 2 + e.getValue().length())
+            .mapToInt(e -> 2 + stringByteSize(e.getKey()) + 2 + stringByteSize(e.getValue()))
             .sum();
   }
 
-  private static ByteBuf writeCollection(ByteBuf bb, Collection<String> elements) {
+  private static int stringByteSize(String string) {
+    return string.getBytes(CHARSET).length;
+  }
+
+  private static void writeString(ByteBuf bb, String string) {
+    byte[] bytes = string.getBytes(CHARSET);
+    bb.writeShort(bytes.length);
+    bb.writeBytes(bytes);
+  }
+
+  private static void writeCollection(ByteBuf bb, Collection<String> elements) {
     bb.writeInt(elements.size());
-    elements.forEach(e -> bb.writeShort(e.length()).writeBytes(e.getBytes(CHARSET)));
-    return bb;
+    elements.forEach(e -> writeString(bb, e));
   }
 
-  private static ByteBuf writeArray(ByteBuf bb, String... elements) {
-    return writeCollection(bb, asList(elements));
+  private static void writeArray(ByteBuf bb, String... elements) {
+    writeCollection(bb, asList(elements));
   }
 
-  private static ByteBuf writeMap(ByteBuf bb, Map<String, String> elements) {
+  private static void writeMap(ByteBuf bb, Map<String, String> elements) {
     bb.writeInt(elements.size());
     elements.forEach(
-        (key, value) ->
-            bb.writeShort(key.length())
-                .writeBytes(key.getBytes(CHARSET))
-                .writeShort(value.length())
-                .writeBytes(value.getBytes(CHARSET)));
-    return bb;
+        (key, value) -> {
+          writeString(bb, key);
+          writeString(bb, value);
+        });
   }
 
   ByteBuf allocate(ByteBufAllocator allocator, int capacity) {
@@ -934,7 +935,7 @@ public class Client implements AutoCloseable {
   }
 
   public Response delete(String stream) {
-    int length = 2 + 2 + 4 + 2 + stream.length();
+    int length = 2 + 2 + 4 + 2 + stringByteSize(stream);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -942,8 +943,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_DELETE_STREAM));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, stream);
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -992,12 +992,12 @@ public class Client implements AutoCloseable {
     int publisherReferenceSize =
         (publisherReference == null || publisherReference.isEmpty()
             ? 0
-            : publisherReference.length());
-    if (publisherReferenceSize >= MAX_REFERENCE_SIZE) {
+            : stringByteSize(publisherReference));
+    if (publisherReference != null && publisherReferenceSize >= MAX_REFERENCE_SIZE) {
       throw new IllegalArgumentException(
-          "If specified, publisher reference must less than 256 characters");
+          "If specified, publisher reference must be less than 256 bytes when encoded as UTF-8");
     }
-    int length = 2 + 2 + 4 + 1 + 2 + publisherReferenceSize + 2 + stream.length();
+    int length = 2 + 2 + 4 + 1 + 2 + publisherReferenceSize + 2 + stringByteSize(stream);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -1006,12 +1006,12 @@ public class Client implements AutoCloseable {
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
       bb.writeByte(publisherId);
-      bb.writeShort(publisherReferenceSize);
-      if (publisherReferenceSize > 0) {
-        bb.writeBytes(publisherReference.getBytes(CHARSET));
+      if (publisherReference == null || publisherReference.isEmpty()) {
+        bb.writeShort(0);
+      } else {
+        writeString(bb, publisherReference);
       }
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, stream);
       OutstandingRequest<Response> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -1342,7 +1342,7 @@ public class Client implements AutoCloseable {
     if (initialCredits < 0 || initialCredits > Short.MAX_VALUE) {
       throw new IllegalArgumentException("Credit value must be between 0 and " + Short.MAX_VALUE);
     }
-    int length = 2 + 2 + 4 + 1 + 2 + stream.length() + 2 + 2; // misses the offset
+    int length = 2 + 2 + 4 + 1 + 2 + stringByteSize(stream) + 2 + 2; // misses the offset
     if (offsetSpecification.isOffset() || offsetSpecification.isTimestamp()) {
       length += 8;
     }
@@ -1359,8 +1359,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
       bb.writeByte(subscriptionId);
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, stream);
       bb.writeShort(offsetSpecification.getType());
       if (offsetSpecification.isOffset() || offsetSpecification.isTimestamp()) {
         bb.writeLong(offsetSpecification.getOffset());
@@ -1388,36 +1387,36 @@ public class Client implements AutoCloseable {
   }
 
   public void storeOffset(String reference, String stream, long offset) {
-    if (reference == null || reference.isEmpty() || reference.length() >= MAX_REFERENCE_SIZE) {
+    if (reference == null
+        || reference.isEmpty()
+        || stringByteSize(reference) >= MAX_REFERENCE_SIZE) {
       throw new IllegalArgumentException(
-          "Reference must a non-empty string of less than 256 characters");
+          "Reference must be a non-empty string of less than 256 bytes when encoded as UTF-8");
     }
     if (stream == null || stream.isEmpty()) {
       throw new IllegalArgumentException("Stream cannot be null or empty");
     }
-    int length = 2 + 2 + 2 + reference.length() + 2 + stream.length() + 8;
+    int length = 2 + 2 + 2 + stringByteSize(reference) + 2 + stringByteSize(stream) + 8;
     ByteBuf bb = allocate(length + 4);
     bb.writeInt(length);
     bb.writeShort(encodeRequestCode(COMMAND_STORE_OFFSET));
     bb.writeShort(VERSION_1);
-    bb.writeShort(reference.length());
-    bb.writeBytes(reference.getBytes(CHARSET));
-    bb.writeShort(stream.length());
-    bb.writeBytes(stream.getBytes(CHARSET));
+    writeString(bb, reference);
+    writeString(bb, stream);
     bb.writeLong(offset);
     channel.writeAndFlush(bb, channel.voidPromise());
   }
 
   public QueryOffsetResponse queryOffset(String reference, String stream) {
-    if (reference == null || reference.isEmpty() || reference.length() > 256) {
+    if (reference == null || reference.isEmpty() || stringByteSize(reference) > 256) {
       throw new IllegalArgumentException(
-          "Reference must a non-empty string of less than 256 characters");
+          "Reference must be a non-empty string of less than 256 bytes when encoded as UTF-8");
     }
     if (stream == null || stream.isEmpty()) {
       throw new IllegalArgumentException("Stream cannot be null or empty");
     }
 
-    int length = 2 + 2 + 4 + 2 + reference.length() + 2 + stream.length();
+    int length = 2 + 2 + 4 + 2 + stringByteSize(reference) + 2 + stringByteSize(stream);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -1425,10 +1424,8 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_QUERY_OFFSET));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(reference.length());
-      bb.writeBytes(reference.getBytes(CHARSET));
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, reference);
+      writeString(bb, stream);
       OutstandingRequest<QueryOffsetResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -1480,7 +1477,7 @@ public class Client implements AutoCloseable {
             + 2
             + 4
             + 2
-            + stream.length()
+            + stringByteSize(stream)
             + 2; // API code, version, correlation ID, stream, offset type
     if (offsetSpecification.isOffset() || offsetSpecification.isTimestamp()) {
       length += 8;
@@ -1498,8 +1495,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_RESOLVE_OFFSET_SPEC));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, stream);
       bb.writeShort(offsetSpecification.getType());
       if (offsetSpecification.isOffset() || offsetSpecification.isTimestamp()) {
         bb.writeLong(offsetSpecification.getOffset());
@@ -1524,15 +1520,15 @@ public class Client implements AutoCloseable {
   public long queryPublisherSequence(String publisherReference, String stream) {
     if (publisherReference == null
         || publisherReference.isEmpty()
-        || publisherReference.length() > 256) {
+        || stringByteSize(publisherReference) > 256) {
       throw new IllegalArgumentException(
-          "Publisher reference must a non-empty string of less than 256 characters");
+          "Publisher reference must be a non-empty string of less than 256 bytes when encoded as UTF-8");
     }
     if (stream == null || stream.isEmpty()) {
       throw new IllegalArgumentException("Stream cannot be null or empty");
     }
 
-    int length = 2 + 2 + 4 + 2 + publisherReference.length() + 2 + stream.length();
+    int length = 2 + 2 + 4 + 2 + stringByteSize(publisherReference) + 2 + stringByteSize(stream);
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -1540,10 +1536,8 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_QUERY_PUBLISHER_SEQUENCE));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(publisherReference.length());
-      bb.writeBytes(publisherReference.getBytes(CHARSET));
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, publisherReference);
+      writeString(bb, stream);
       OutstandingRequest<QueryPublisherSequenceResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -1730,9 +1724,9 @@ public class Client implements AutoCloseable {
             + 2
             + 4
             + 2
-            + routingKey.length()
+            + stringByteSize(routingKey)
             + 2
-            + superStream.length(); // API code, version, correlation ID, 2 strings
+            + stringByteSize(superStream); // API code, version, correlation ID, 2 strings
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -1740,10 +1734,8 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_ROUTE));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(routingKey.length());
-      bb.writeBytes(routingKey.getBytes(CHARSET));
-      bb.writeShort(superStream.length());
-      bb.writeBytes(superStream.getBytes(CHARSET));
+      writeString(bb, routingKey);
+      writeString(bb, superStream);
       OutstandingRequest<List<String>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -1766,7 +1758,7 @@ public class Client implements AutoCloseable {
       throw new IllegalArgumentException("stream must not be null");
     }
     int length =
-        2 + 2 + 4 + 2 + superStream.length(); // API code, version, correlation ID, 1 string
+        2 + 2 + 4 + 2 + stringByteSize(superStream); // API code, version, correlation ID, 1 string
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -1774,8 +1766,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_PARTITIONS));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(superStream.length());
-      bb.writeBytes(superStream.getBytes(CHARSET));
+      writeString(bb, superStream);
       OutstandingRequest<List<String>> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));
@@ -1825,7 +1816,8 @@ public class Client implements AutoCloseable {
     if (stream == null) {
       throw new IllegalArgumentException("stream must not be null");
     }
-    int length = 2 + 2 + 4 + 2 + stream.length(); // API code, version, correlation ID, 1 string
+    int length =
+        2 + 2 + 4 + 2 + stringByteSize(stream); // API code, version, correlation ID, 1 string
     int correlationId = nextCorrelationId();
     try {
       ByteBuf bb = allocate(length + 4);
@@ -1833,8 +1825,7 @@ public class Client implements AutoCloseable {
       bb.writeShort(encodeRequestCode(COMMAND_STREAM_STATS));
       bb.writeShort(VERSION_1);
       bb.writeInt(correlationId);
-      bb.writeShort(stream.length());
-      bb.writeBytes(stream.getBytes(CHARSET));
+      writeString(bb, stream);
       OutstandingRequest<StreamStatsResponse> request = outstandingRequest();
       outstandingRequests.put(correlationId, request);
       channel.writeAndFlush(bb).addListener(maybeFailRpc(correlationId));

--- a/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
@@ -265,11 +265,21 @@ class ServerFrameHandler {
     return (OutstandingRequest<T>) outstandingRequests.remove(correlationId);
   }
 
-  private static String readString(ByteBuf bb) {
+  static class StringPayload {
+    final String value;
+    final short byteLength;
+
+    StringPayload(String value, short byteLength) {
+      this.value = value;
+      this.byteLength = byteLength;
+    }
+  }
+
+  private static StringPayload readString(ByteBuf bb) {
     short size = bb.readShort();
     byte[] bytes = new byte[size];
     bb.readBytes(bytes);
-    return new String(bytes, StandardCharsets.UTF_8);
+    return new StringPayload(new String(bytes, StandardCharsets.UTF_8), size);
   }
 
   interface FrameHandler {
@@ -677,10 +687,10 @@ class ServerFrameHandler {
       short code = message.readShort();
       int read = 2;
       if (code == RESPONSE_CODE_STREAM_NOT_AVAILABLE) {
-        String stream = readString(message);
-        LOGGER.debug("Stream {} is no longer available", stream);
-        read += (2 + stream.length());
-        client.metadataListener.handle(stream, code);
+        StringPayload stream = readString(message);
+        LOGGER.debug("Stream {} is no longer available", stream.value);
+        read += (2 + stream.byteLength);
+        client.metadataListener.handle(stream.value, code);
       } else {
         throw new IllegalArgumentException("Unsupported metadata update code " + code);
       }
@@ -696,10 +706,10 @@ class ServerFrameHandler {
       int read = 4;
       short closeCode = message.readShort();
       read += 2;
-      String closeReason = readString(message);
-      read += 2 + closeReason.length();
+      StringPayload closeReason = readString(message);
+      read += 2 + closeReason.byteLength;
 
-      LOGGER.info("Received close from server, reason: {} {}", closeCode, closeReason);
+      LOGGER.info("Received close from server, reason: {} {}", closeCode, closeReason.value);
 
       int length = 2 + 2 + 4 + 2;
       ByteBuf byteBuf = client.allocate(ctx.alloc(), length + 4);
@@ -837,11 +847,11 @@ class ServerFrameHandler {
       Map<String, String> serverProperties = new LinkedHashMap<>(serverPropertiesCount);
 
       for (int i = 0; i < serverPropertiesCount; i++) {
-        String key = readString(message);
-        read += 2 + key.length();
-        String value = readString(message);
-        read += 2 + value.length();
-        serverProperties.put(key, value);
+        StringPayload key = readString(message);
+        read += 2 + key.byteLength;
+        StringPayload value = readString(message);
+        read += 2 + value.byteLength;
+        serverProperties.put(key.value, value.value);
       }
 
       OutstandingRequest<Map<String, String>> outstandingRequest =
@@ -872,11 +882,11 @@ class ServerFrameHandler {
         read += 4;
         connectionProperties = new LinkedHashMap<>(connectionPropertiesCount);
         for (int i = 0; i < connectionPropertiesCount; i++) {
-          String key = readString(message);
-          read += 2 + key.length();
-          String value = readString(message);
-          read += 2 + value.length();
-          connectionProperties.put(key, value);
+          StringPayload key = readString(message);
+          read += 2 + key.byteLength;
+          StringPayload value = readString(message);
+          read += 2 + value.byteLength;
+          connectionProperties.put(key.value, value.value);
         }
       } else {
         connectionProperties = Collections.emptyMap();
@@ -1006,9 +1016,9 @@ class ServerFrameHandler {
       read += 4;
       List<String> mechanisms = new ArrayList<>(mechanismsCount);
       for (int i = 0; i < mechanismsCount; i++) {
-        String mechanism = readString(message);
-        mechanisms.add(mechanism);
-        read += 2 + mechanism.length();
+        StringPayload mechanism = readString(message);
+        mechanisms.add(mechanism.value);
+        read += 2 + mechanism.byteLength;
       }
 
       OutstandingRequest<List<String>> outstandingRequest =
@@ -1038,19 +1048,19 @@ class ServerFrameHandler {
       for (int i = 0; i < brokersCount; i++) {
         short brokerReference = message.readShort();
         read += 2;
-        String host = readString(message);
-        read += 2 + host.length();
+        StringPayload host = readString(message);
+        read += 2 + host.byteLength;
         int port = message.readInt();
         read += 4;
-        brokers.put(brokerReference, new Broker(host, port));
+        brokers.put(brokerReference, new Broker(host.value, port));
       }
 
       int streamsCount = message.readInt();
       Map<String, StreamMetadata> results = new LinkedHashMap<>(streamsCount);
       read += 4;
       for (int i = 0; i < streamsCount; i++) {
-        String stream = readString(message);
-        read += 2 + stream.length();
+        StringPayload stream = readString(message);
+        read += 2 + stream.byteLength;
         short responseCode = message.readShort();
         read += 2;
         short leaderReference = message.readShort();
@@ -1069,15 +1079,12 @@ class ServerFrameHandler {
           }
         }
         StreamMetadata streamMetadata =
-            new StreamMetadata(stream, responseCode, brokers.get(leaderReference), replicas);
-        results.put(stream, streamMetadata);
+            new StreamMetadata(stream.value, responseCode, brokers.get(leaderReference), replicas);
+        results.put(stream.value, streamMetadata);
       }
 
       OutstandingRequest<Map<String, StreamMetadata>> outstandingRequest =
-          remove(
-              client.outstandingRequests,
-              correlationId,
-              new ParameterizedTypeReference<Map<String, StreamMetadata>>() {});
+          remove(client.outstandingRequests, correlationId, new ParameterizedTypeReference<>() {});
       if (outstandingRequest == null) {
         logMissingOutstandingRequest(correlationId);
       } else {
@@ -1126,9 +1133,9 @@ class ServerFrameHandler {
       } else {
         streams = new ArrayList<>(streamCount);
         for (int i = 0; i < streamCount; i++) {
-          String stream = readString(message);
-          read += (2 + stream.length());
-          streams.add(stream);
+          StringPayload stream = readString(message);
+          read += (2 + stream.byteLength);
+          streams.add(stream.value);
         }
       }
 
@@ -1165,9 +1172,9 @@ class ServerFrameHandler {
       } else {
         streams = new ArrayList<>(streamCount);
         for (int i = 0; i < streamCount; i++) {
-          String stream = readString(message);
-          read += (2 + stream.length());
-          streams.add(stream);
+          StringPayload stream = readString(message);
+          read += (2 + stream.byteLength);
+          streams.add(stream.value);
         }
       }
 
@@ -1250,10 +1257,10 @@ class ServerFrameHandler {
       Map<String, Long> info = new LinkedHashMap<>(infoCount);
 
       for (int i = 0; i < infoCount; i++) {
-        String key = readString(message);
-        read += 2 + key.length();
+        StringPayload key = readString(message);
+        read += 2 + key.byteLength;
         long value = message.readLong();
-        info.put(key, value);
+        info.put(key.value, value);
         read += 8;
       }
 

--- a/src/test/java/com/rabbitmq/stream/impl/ClientTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ClientTest.java
@@ -1212,4 +1212,117 @@ public class ClientTest {
     assertThat(response).is(ko());
     assertThat(response.getResponseCode()).isEqualTo(Constants.RESPONSE_CODE_STREAM_DOES_NOT_EXIST);
   }
+
+  @Test
+  void utf8StringsInStreamOperations(TestInfo info) throws Exception {
+    // Test strings with UTF-8 characters (non-ASCII)
+    String streamWithUTF8 = streamName(info) + "-café-🚀";
+    String publisherRef = "ref-référence-🎯";
+    String offsetRef = "offset-référence-📍";
+    String superStreamWithUTF8 = streamName(info) + "-super-café-🌟";
+    String routingKeyWithUTF8 = "routing-clé-🔑";
+
+    Client client = cf.get();
+
+    try {
+      // Test create stream with UTF-8 name
+      Response response = client.create(streamWithUTF8);
+      assertThat(response).is(ok());
+
+      // Test declare publisher with UTF-8 reference and stream name
+      response = client.declarePublisher(b(1), publisherRef, streamWithUTF8);
+      assertThat(response).is(ok());
+
+      // Publish a message to establish some content
+      List<Message> messages =
+          Collections.singletonList(client.messageBuilder().addData("hello".getBytes()).build());
+      client.publish(b(1), messages);
+
+      // Test store and query offset with UTF-8 reference
+      long offset = 42L;
+      client.storeOffset(offsetRef, streamWithUTF8, offset);
+      Thread.sleep(100); // storeOffset is fire-and-forget, give it time
+      waitAtMost(
+          () -> {
+            Client.QueryOffsetResponse r = client.queryOffset(offsetRef, streamWithUTF8);
+            return r.isOk() && r.getOffset() == offset;
+          });
+
+      Client.QueryOffsetResponse offsetResponse = client.queryOffset(offsetRef, streamWithUTF8);
+      assertThat(offsetResponse).is(ok());
+      assertThat(offsetResponse.getOffset()).isEqualTo(offset);
+
+      // Test query publisher sequence with UTF-8 reference
+      long sequence = client.queryPublisherSequence(publisherRef, streamWithUTF8);
+      assertThat(sequence).isGreaterThanOrEqualTo(0L);
+      client.deletePublisher(b(1));
+
+      // Test super stream operations with UTF-8 strings
+      List<String> partitionsWithUTF8 =
+          Arrays.asList(streamWithUTF8 + "-partition-0", streamWithUTF8 + "-partition-1");
+      List<String> bindingKeysWithUTF8 =
+          Arrays.asList(routingKeyWithUTF8 + "-0", routingKeyWithUTF8 + "-1");
+
+      response =
+          client.createSuperStream(
+              superStreamWithUTF8, partitionsWithUTF8, bindingKeysWithUTF8, Collections.emptyMap());
+      assertThat(response).is(ok());
+
+      // Test route with UTF-8 routing key and super stream name
+      List<String> routeResult = client.route(routingKeyWithUTF8 + "-0", superStreamWithUTF8);
+      assertThat(routeResult).isNotEmpty();
+
+      // Test partitions with UTF-8 super stream name
+      List<String> partitions = client.partitions(superStreamWithUTF8);
+      assertThat(partitions).hasSize(2);
+
+      // Clean up super stream
+      client.deleteSuperStream(superStreamWithUTF8);
+
+    } finally {
+      // Clean up regular stream
+      try {
+        client.delete(streamWithUTF8);
+      } catch (Exception e) {
+        // ignore cleanup errors
+      }
+    }
+  }
+
+  @Test
+  void utf8StringLengthValidation() {
+    Client client = cf.get();
+
+    // Test publisher reference that's valid in character count but too big in byte count
+    StringBuilder longUTF8Reference = new StringBuilder();
+    // Each "𝒜" is 4 bytes in UTF-8, so 64 of them = 256 bytes (at the limit)
+    for (int i = 0; i < 64; i++) {
+      longUTF8Reference.append("𝒜");
+    }
+    String refAt256Bytes = longUTF8Reference.toString();
+
+    // This should be allowed (exactly at limit)
+    assertThat(refAt256Bytes.getBytes(UTF8)).hasSize(256);
+
+    // Add one more character to exceed the limit
+    String refOver256Bytes = refAt256Bytes + "𝒜";
+    assertThat(refOver256Bytes.getBytes(UTF8)).hasSize(260);
+
+    // Test that the validation properly checks UTF-8 byte length, not character count
+    assertThatThrownBy(() -> client.declarePublisher(b(1), refOver256Bytes, stream))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("less than 256 bytes when encoded as UTF-8");
+
+    assertThatThrownBy(() -> client.storeOffset(refOver256Bytes, stream, 0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("less than 256 bytes when encoded as UTF-8");
+
+    assertThatThrownBy(() -> client.queryOffset(refOver256Bytes, stream))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("less than 256 bytes when encoded as UTF-8");
+
+    assertThatThrownBy(() -> client.queryPublisherSequence(refOver256Bytes, stream))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("less than 256 bytes when encoded as UTF-8");
+  }
 }


### PR DESCRIPTION
The client was using String.length() instead of UTF-8 byte length for frame prefixes and incoming frame byte tracking. This caused incorrect prefixes, undersized buffers, and decode loop warnings on non-ASCII strings.

* Client: Use stringByteSize and writeString to enforce true byte length.
* ServerFrameHandler: Return StringPayload (value + byteLength) from readString and update handlers to track consumed bytes accurately.
* Tests: Added integration and validation tests for non-ASCII operations.