### PR TITLE
Cap decompression in delivery loop

### DIFF
--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -214,6 +214,15 @@ The limit may not be strictly enforced in case of too many concurrent creations.
 |Heartbeat requested by the client.
 |60 seconds
 
+|`maxUncompressedSubEntryBatchSize`
+|The maximum uncompressed size of a single sub-entry batch.
+The broker enforces the same limit when messages are published and should be configured with the same value.
+|67108864 (64 MiB)
+
+|`maxUncompressedSizePerChunk`
+|The maximum total uncompressed size of the sub-entry batches in a single chunk.
+|1073741824 (1 GiB)
+
 |`forceReplicaForConsumers`
 |Retry connecting until a replica is available for consumers.
 The client retries 5 times before falling back to the stream leader node.

--- a/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
@@ -231,6 +231,38 @@ public interface EnvironmentBuilder {
   EnvironmentBuilder maxFrameSizeBeforeAuthentication(int maxFrameSizeBeforeAuthentication);
 
   /**
+   * The maximum uncompressed size of a single sub-entry batch.
+   *
+   * <p>A sub-entry batch header is written by the publishing client, stored verbatim by the broker,
+   * and replayed to consumers. Consumers must decompress a batch before they can decode any of its
+   * records, so this setting bounds the heap a single frame can commit on the message dispatching
+   * thread.
+   *
+   * <p>Default is 67108864 (64 MiB). The broker enforces the same limit when messages are published
+   * and should be configured with the same value: a batch larger than the broker's limit is
+   * rejected at publish time, whereas a batch larger than this client's limit but within the
+   * broker's is stored and then fails on every consumer.
+   *
+   * @param maxUncompressedSubEntryBatchSize
+   * @return this builder instance
+   */
+  EnvironmentBuilder maxUncompressedSubEntryBatchSize(int maxUncompressedSubEntryBatchSize);
+
+  /**
+   * The maximum total uncompressed size of the sub-entry batches in a single chunk.
+   *
+   * <p>A chunk can hold many sub-entry batches, so {@link #maxUncompressedSubEntryBatchSize(int)}
+   * alone does not bound the aggregate decompression work a single frame can demand on the message
+   * dispatching thread. This setting bounds that aggregate.
+   *
+   * <p>Default is 1073741824 (1 GiB).
+   *
+   * @param maxUncompressedSizePerChunk
+   * @return this builder instance
+   */
+  EnvironmentBuilder maxUncompressedSizePerChunk(int maxUncompressedSizePerChunk);
+
+  /**
    * The checksum strategy used for chunk checksum.
    *
    * <p>The default is CRC32 based on JDK implementation.

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -173,6 +173,13 @@ public class Client implements AutoCloseable {
   // used before the max frame size is negotiated with the server (tune/open exchange), so the
   // client is never exposed to an unbounded or overly large frame from an unauthenticated peer
   static final int DEFAULT_MAX_FRAME_SIZE_BEFORE_AUTHENTICATION = 8192;
+  // absolute cap on the decompressed size of one sub-entry batch, bounding the heap a single
+  // frame can commit on the event loop thread
+  static final int DEFAULT_MAX_UNCOMPRESSED_SUB_ENTRY_BATCH_SIZE = 64 * 1024 * 1024;
+  // bounds the total decompression work one frame (one chunk) can demand on the event loop
+  // thread: a chunk holds many entries, so the per-entry cap above does not bound the aggregate
+  static final int DEFAULT_MAX_UNCOMPRESSED_SIZE_PER_CHUNK =
+      16 * DEFAULT_MAX_UNCOMPRESSED_SUB_ENTRY_BATCH_SIZE;
   static final OutboundEntityWriteCallback OUTBOUND_MESSAGE_WRITE_CALLBACK =
       new OutboundMessageWriteCallback();
   static final OutboundEntityWriteCallback OUTBOUND_MESSAGE_BATCH_WRITE_CALLBACK =
@@ -233,6 +240,8 @@ public class Client implements AutoCloseable {
   private final Runnable nettyClosing;
   private final int maxFrameSize;
   private final boolean frameSizeCapped;
+  private final int maxUncompressedSubEntryBatchSize;
+  private final int maxUncompressedSizePerChunk;
   private final EventLoopGroup eventLoopGroup;
   private final Map<String, String> clientProperties;
   private final String host;
@@ -266,6 +275,8 @@ public class Client implements AutoCloseable {
     this.saslConfiguration = parameters.saslConfiguration;
     this.chunkChecksum = parameters.chunkChecksum;
     this.metricsCollector = parameters.metricsCollector;
+    this.maxUncompressedSubEntryBatchSize = parameters.maxUncompressedSubEntryBatchSize;
+    this.maxUncompressedSizePerChunk = parameters.maxUncompressedSizePerChunk;
     this.metadataListener = parameters.metadataListener;
     this.consumerUpdateListener = parameters.consumerUpdateListener;
     this.compressionCodecFactory =
@@ -575,6 +586,14 @@ public class Client implements AutoCloseable {
 
   int maxFrameSize() {
     return this.maxFrameSize;
+  }
+
+  int maxUncompressedSubEntryBatchSize() {
+    return this.maxUncompressedSubEntryBatchSize;
+  }
+
+  int maxUncompressedSizePerChunk() {
+    return this.maxUncompressedSizePerChunk;
   }
 
   private int nextCorrelationId() {
@@ -2378,6 +2397,8 @@ public class Client implements AutoCloseable {
     private Duration requestedHeartbeat = Duration.ofSeconds(60);
     private int requestedMaxFrameSize = DEFAULT_MAX_FRAME_SIZE;
     private int maxFrameSizeBeforeAuthentication = DEFAULT_MAX_FRAME_SIZE_BEFORE_AUTHENTICATION;
+    private int maxUncompressedSubEntryBatchSize = DEFAULT_MAX_UNCOMPRESSED_SUB_ENTRY_BATCH_SIZE;
+    private int maxUncompressedSizePerChunk = DEFAULT_MAX_UNCOMPRESSED_SIZE_PER_CHUNK;
     private PublishConfirmListener publishConfirmListener = NO_OP_PUBLISH_CONFIRM_LISTENER;
     private PublishErrorListener publishErrorListener = NO_OP_PUBLISH_ERROR_LISTENER;
     private ChunkListener chunkListener =
@@ -2428,6 +2449,8 @@ public class Client implements AutoCloseable {
       this.requestedHeartbeat = other.requestedHeartbeat;
       this.requestedMaxFrameSize = other.requestedMaxFrameSize;
       this.maxFrameSizeBeforeAuthentication = other.maxFrameSizeBeforeAuthentication;
+      this.maxUncompressedSubEntryBatchSize = other.maxUncompressedSubEntryBatchSize;
+      this.maxUncompressedSizePerChunk = other.maxUncompressedSizePerChunk;
       this.publishConfirmListener = other.publishConfirmListener;
       this.publishErrorListener = other.publishErrorListener;
       this.chunkListener = other.chunkListener;
@@ -2567,6 +2590,23 @@ public class Client implements AutoCloseable {
 
     public ClientParameters maxFrameSizeBeforeAuthentication(int maxFrameSizeBeforeAuthentication) {
       this.maxFrameSizeBeforeAuthentication = maxFrameSizeBeforeAuthentication;
+      return this;
+    }
+
+    public ClientParameters maxUncompressedSubEntryBatchSize(int maxUncompressedSubEntryBatchSize) {
+      if (maxUncompressedSubEntryBatchSize <= 0) {
+        throw new IllegalArgumentException(
+            "maxUncompressedSubEntryBatchSize must be greater than 0");
+      }
+      this.maxUncompressedSubEntryBatchSize = maxUncompressedSubEntryBatchSize;
+      return this;
+    }
+
+    public ClientParameters maxUncompressedSizePerChunk(int maxUncompressedSizePerChunk) {
+      if (maxUncompressedSizePerChunk <= 0) {
+        throw new IllegalArgumentException("maxUncompressedSizePerChunk must be greater than 0");
+      }
+      this.maxUncompressedSizePerChunk = maxUncompressedSizePerChunk;
       return this;
     }
 

--- a/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
+++ b/src/main/java/com/rabbitmq/stream/impl/ServerFrameHandler.java
@@ -98,9 +98,11 @@ class ServerFrameHandler {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerFrameHandler.class);
   private static final FrameHandler RESPONSE_FRAME_HANDLER = new ResponseFrameHandler();
-  // sanity bound on declared uncompressed size vs. actual compressed size, to guard
-  // against a malicious/corrupted frame triggering an oversized buffer allocation
-  private static final int MAX_COMPRESSION_RATIO = 1024;
+  // initial capacity of the decompression buffer, it grows as needed up to the declared
+  // uncompressed size
+  static final int INITIAL_DECOMPRESSION_BUFFER_SIZE = 64 * 1024;
+  // transfer buffer size
+  private static final int DECOMPRESSION_TRANSFER_BUFFER_SIZE = 1024;
 
   private static final FrameHandler[][] HANDLERS;
 
@@ -538,6 +540,11 @@ class ServerFrameHandler {
       metricsCollector.chunk(numEntries);
       MutableBoolean messageIgnored = new MutableBoolean(false);
 
+      // bounds the total decompression work one frame can demand on the message dispatch thread:
+      // the
+      // per-entry cap bounds memory, but a chunk holds many entries
+      long decompressionBudget = client.maxUncompressedSizePerChunk();
+
       while (numRecords != 0) {
         byte entryType = message.readByte();
         if ((entryType & 0x80) == 0) {
@@ -600,78 +607,114 @@ class ServerFrameHandler {
           read += 4;
           checkSize(dataSize, message);
           if (uncompressedDataSize < 0
-              || uncompressedDataSize > (long) dataSize * MAX_COMPRESSION_RATIO) {
+              || uncompressedDataSize > client.maxUncompressedSubEntryBatchSize()) {
             throw new StreamException(
-                "Invalid uncompressed data size "
+                "Uncompressed sub-entry batch size "
                     + uncompressedDataSize
-                    + " for compressed size "
-                    + dataSize);
+                    + " exceeds the maximum of "
+                    + client.maxUncompressedSubEntryBatchSize()
+                    + " byte(s), it can be increased with"
+                    + " EnvironmentBuilder#maxUncompressedSubEntryBatchSize(int)");
+          }
+          if (comp.code() != Compression.NONE.code()) {
+            decompressionBudget -= uncompressedDataSize;
+            if (decompressionBudget < 0) {
+              throw new StreamException(
+                  "Chunk at offset "
+                      + offset
+                      + " declares more than "
+                      + client.maxUncompressedSizePerChunk()
+                      + " byte(s) of uncompressed sub-entry data, it can be increased with"
+                      + " EnvironmentBuilder#maxUncompressedSizePerChunk(int)");
+            }
+          }
+          if (numRecordsInBatch == 0) {
+            LOGGER.debug("Sub-batch entry declares 0 record(s)");
           }
 
           int readBeforeSubEntries = read;
           ByteBuf bbToReadFrom = message;
-          if (comp.code() != Compression.NONE.code()) {
-            CompressionCodec compressionCodec = client.compressionCodecFactory.get(comp);
-            ByteBuf outBb = ctx.alloc().heapBuffer(uncompressedDataSize);
-            byte[] inBuffer = new byte[Math.min(uncompressedDataSize, 1024)];
-            int n;
-            ByteBuf slice = message.slice(message.readerIndex(), dataSize);
-            InputStream inputStream = null;
-            try {
-              inputStream = compressionCodec.decompress(new ByteBufInputStream(slice));
-              while (-1 != (n = inputStream.read(inBuffer))) {
-                outBb.writeBytes(inBuffer, 0, n);
-              }
-            } catch (Throwable e) {
-              // compression codecs may use native libraries, so we can end up
-              // with throwables or errors
-              throw new StreamException("Error while uncompressing sub-entry", e);
-            } finally {
-              if (inputStream != null) {
-                try {
-                  inputStream.close();
-                } catch (IOException e) {
-                  throw new StreamException(
-                      "Error while closing sub-entry compressed input stream", e);
+          ByteBuf outBb = null;
+          try {
+            if (comp.code() != Compression.NONE.code()) {
+              CompressionCodec compressionCodec = client.compressionCodecFactory.get(comp);
+              int initialCapacity =
+                  Math.min(uncompressedDataSize, INITIAL_DECOMPRESSION_BUFFER_SIZE);
+              // bounding maxCapacity makes the declared uncompressed size a hard limit: a
+              // stream producing more than it declared fails instead of growing without limit
+              outBb = ctx.alloc().heapBuffer(initialCapacity, uncompressedDataSize);
+              // shrink the transfer buffer for small declared sizes, but never to zero:
+              // read(byte[0]) returns 0 forever, not -1
+              byte[] inBuffer =
+                  new byte
+                      [uncompressedDataSize > 0
+                          ? Math.min(uncompressedDataSize, DECOMPRESSION_TRANSFER_BUFFER_SIZE)
+                          : DECOMPRESSION_TRANSFER_BUFFER_SIZE];
+              int n;
+              ByteBuf slice = message.slice(message.readerIndex(), dataSize);
+              InputStream inputStream = null;
+              try {
+                inputStream = compressionCodec.decompress(new ByteBufInputStream(slice));
+                while (-1 != (n = inputStream.read(inBuffer))) {
+                  outBb.writeBytes(inBuffer, 0, n);
+                }
+              } catch (Throwable e) {
+                // compression codecs may use native libraries, so we can end up
+                // with throwables or errors
+                throw new StreamException("Error while uncompressing sub-entry", e);
+              } finally {
+                if (inputStream != null) {
+                  try {
+                    inputStream.close();
+                  } catch (IOException e) {
+                    throw new StreamException(
+                        "Error while closing sub-entry compressed input stream", e);
+                  }
                 }
               }
+              message.readerIndex(message.readerIndex() + dataSize);
+              bbToReadFrom = outBb;
             }
-            message.readerIndex(message.readerIndex() + dataSize);
-            bbToReadFrom = outBb;
-          }
 
-          numRecords -= numRecordsInBatch;
+            // every sub-entry carries at least its own 4-byte length prefix
+            checkCount(numRecordsInBatch, 4, bbToReadFrom);
 
-          while (numRecordsInBatch != 0) {
-            read =
-                handleMessage(
-                    bbToReadFrom,
-                    read,
-                    ignore,
-                    messageIgnored,
-                    offset,
-                    offsetLimit,
-                    chunkTimestamp,
-                    committedOffset,
-                    codec,
-                    messageListener,
-                    subscriptionId,
-                    chunkContext);
-            if (messageIgnored.get()) {
-              messageIgnoredListener.ignored(
-                  subscriptionId, offset, chunkTimestamp, committedOffset, chunkContext);
-              messageIgnored.set(false);
-            } else {
-              metricsCollector.consume(1);
+            numRecords -= numRecordsInBatch;
+
+            while (numRecordsInBatch != 0) {
+              read =
+                  handleMessage(
+                      bbToReadFrom,
+                      read,
+                      ignore,
+                      messageIgnored,
+                      offset,
+                      offsetLimit,
+                      chunkTimestamp,
+                      committedOffset,
+                      codec,
+                      messageListener,
+                      subscriptionId,
+                      chunkContext);
+              if (messageIgnored.get()) {
+                messageIgnoredListener.ignored(
+                    subscriptionId, offset, chunkTimestamp, committedOffset, chunkContext);
+                messageIgnored.set(false);
+              } else {
+                metricsCollector.consume(1);
+              }
+              numRecordsInBatch--;
+              offset++; // works even for unsigned long
             }
-            numRecordsInBatch--;
-            offset++; // works even for unsigned long
-          }
 
-          if (comp.code() != Compression.NONE.code()) {
-            bbToReadFrom.release();
-            // to avoid a warning, we read more from what it's inside the frame with compression
-            read = readBeforeSubEntries + dataSize;
+            if (comp.code() != Compression.NONE.code()) {
+              // to avoid a warning, we read more from what it's inside the frame with compression
+              read = readBeforeSubEntries + dataSize;
+            }
+          } finally {
+            if (outBb != null) {
+              outBb.release();
+            }
           }
         }
       }

--- a/src/main/java/com/rabbitmq/stream/impl/StreamEnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/impl/StreamEnvironmentBuilder.java
@@ -202,6 +202,17 @@ public class StreamEnvironmentBuilder implements EnvironmentBuilder {
     return this;
   }
 
+  public StreamEnvironmentBuilder maxUncompressedSubEntryBatchSize(
+      int maxUncompressedSubEntryBatchSize) {
+    this.clientParameters.maxUncompressedSubEntryBatchSize(maxUncompressedSubEntryBatchSize);
+    return this;
+  }
+
+  public StreamEnvironmentBuilder maxUncompressedSizePerChunk(int maxUncompressedSizePerChunk) {
+    this.clientParameters.maxUncompressedSizePerChunk(maxUncompressedSizePerChunk);
+    return this;
+  }
+
   public StreamEnvironmentBuilder chunkChecksum(ChunkChecksum chunkChecksum) {
     this.clientParameters.chunkChecksum(chunkChecksum);
     return this;

--- a/src/test/java/com/rabbitmq/stream/impl/ClientParametersTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/ClientParametersTest.java
@@ -51,7 +51,7 @@ public class ClientParametersTest {
     }
 
     assertEquals(
-        31,
+        33,
         nonStaticFields,
         "If this fails, update the copy constructor method to handle the new field(s)");
   }

--- a/src/test/java/com/rabbitmq/stream/impl/StreamProducerTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/StreamProducerTest.java
@@ -651,6 +651,41 @@ public class StreamProducerTest {
   }
 
   @Test
+  void subEntryBatchesWithHighCompressionRatioShouldBeConsumedProperly() {
+    // an identical body per message and a large sub-entry size push the compression ratio well
+    // past what MAX_COMPRESSION_RATIO used to allow (v1.9.0), which broke this kind of batch on
+    // every consumer even though the broker accepted and stored it
+    int messageCount = 5000;
+    byte[] body =
+        "identical repetitive body for a high compression ratio"
+            .repeat(5)
+            .getBytes(StandardCharsets.UTF_8);
+    CountDownLatch publishLatch = new CountDownLatch(messageCount);
+    ConfirmationHandler confirmationHandler = confirmationStatus -> publishLatch.countDown();
+    Producer producer =
+        environment.producerBuilder().stream(stream)
+            .subEntrySize(messageCount)
+            .compression(Compression.ZSTD)
+            .build();
+    IntStream.range(0, messageCount)
+        .forEach(
+            i ->
+                producer.send(
+                    producer.messageBuilder().addData(body).build(), confirmationHandler));
+
+    assertThat(latchAssert(publishLatch)).completes();
+    producer.close();
+
+    CountDownLatch consumeLatch = new CountDownLatch(messageCount);
+    environment.consumerBuilder().stream(stream)
+        .offset(OffsetSpecification.first())
+        .messageHandler((context, message) -> consumeLatch.countDown())
+        .build();
+
+    assertThat(latchAssert(consumeLatch)).completes();
+  }
+
+  @Test
   void methodsShouldThrowExceptionWhenProducerIsClosed() {
     Producer producer = environment.producerBuilder().stream(stream).build();
     producer.close();

--- a/src/test/java/com/rabbitmq/stream/impl/SubEntryDecompressionTest.java
+++ b/src/test/java/com/rabbitmq/stream/impl/SubEntryDecompressionTest.java
@@ -1,0 +1,618 @@
+// Copyright (c) 2020-2026 Broadcom. All Rights Reserved.
+// The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+//
+// This software, the RabbitMQ Stream Java client library, is dual-licensed under the
+// Mozilla Public License 2.0 ("MPL"), and the Apache License version 2 ("ASL").
+// For the MPL, please see LICENSE-MPL-RabbitMQ. For the ASL,
+// please see LICENSE-APACHE2.
+//
+// This software is distributed on an "AS IS" basis, WITHOUT WARRANTY OF ANY KIND,
+// either express or implied. See the LICENSE file for specific language governing
+// rights and limitations of this software.
+//
+// If you have any questions regarding licensing, please contact us at
+// info@rabbitmq.com.
+package com.rabbitmq.stream.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.rabbitmq.stream.ChunkChecksum;
+import com.rabbitmq.stream.Codec;
+import com.rabbitmq.stream.Constants;
+import com.rabbitmq.stream.Message;
+import com.rabbitmq.stream.MessageBuilder;
+import com.rabbitmq.stream.StreamException;
+import com.rabbitmq.stream.codec.ByteArrayEncodedMessage;
+import com.rabbitmq.stream.compression.Compression;
+import com.rabbitmq.stream.compression.CompressionCodec;
+import com.rabbitmq.stream.compression.CompressionCodecFactory;
+import com.rabbitmq.stream.compression.CompressionUtils.GzipCompressionCodec;
+import com.rabbitmq.stream.compression.CompressionUtils.ZstdJniCompressionCodec;
+import com.rabbitmq.stream.compression.DefaultCompressionCodecFactory;
+import com.rabbitmq.stream.impl.Client.CompressedEncodedMessageBatch;
+import com.rabbitmq.stream.impl.ServerFrameHandler.DeliverVersion1FrameHandler;
+import com.rabbitmq.stream.metrics.NoOpMetricsCollector;
+import io.netty.buffer.AbstractByteBufAllocator;
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.ByteBufAllocator;
+import io.netty.buffer.UnpooledByteBufAllocator;
+import io.netty.channel.ChannelHandlerContext;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+public class SubEntryDecompressionTest {
+
+  static final Codec NO_OP_CODEC =
+      new Codec() {
+        @Override
+        public EncodedMessage encode(Message message) {
+          return null;
+        }
+
+        @Override
+        public Message decode(ByteBuf buf, int length) {
+          buf.skipBytes(length);
+          return null;
+        }
+
+        @Override
+        public MessageBuilder messageBuilder() {
+          return null;
+        }
+      };
+
+  @Mock Client client;
+  AutoCloseable mocks;
+
+  @BeforeEach
+  void setUp() {
+    mocks = MockitoAnnotations.openMocks(this);
+    // an unstubbed mock returns 0, which rejects every entry, so every test needs these
+    when(client.maxUncompressedSubEntryBatchSize())
+        .thenReturn(Client.DEFAULT_MAX_UNCOMPRESSED_SUB_ENTRY_BATCH_SIZE);
+    when(client.maxUncompressedSizePerChunk())
+        .thenReturn(Client.DEFAULT_MAX_UNCOMPRESSED_SIZE_PER_CHUNK);
+  }
+
+  @AfterEach
+  void tearDown() throws Exception {
+    mocks.close();
+  }
+
+  private void useCompressionCodec(CompressionCodec codec) throws Exception {
+    Field field = Client.class.getDeclaredField("compressionCodecFactory");
+    field.setAccessible(true);
+    field.set(client, (CompressionCodecFactory) c -> codec);
+  }
+
+  private static ChannelHandlerContext mockContext(ByteBufAllocator allocator) {
+    ChannelHandlerContext ctx = mock(ChannelHandlerContext.class);
+    when(ctx.alloc()).thenReturn(allocator);
+    return ctx;
+  }
+
+  // one sub-batch entry, as written in a chunk's entry list
+  private static final class SubBatchEntry {
+    final byte compressionCode;
+    final int numRecordsInBatch;
+    final int uncompressedDataSize;
+    final byte[] payload;
+
+    SubBatchEntry(
+        byte compressionCode, int numRecordsInBatch, int uncompressedDataSize, byte[] payload) {
+      this.compressionCode = compressionCode;
+      this.numRecordsInBatch = numRecordsInBatch;
+      this.uncompressedDataSize = uncompressedDataSize;
+      this.payload = payload;
+    }
+  }
+
+  // builds a chunk containing the given sub-batch entries, using the header fields under test
+  private static ByteBuf buildChunk(List<SubBatchEntry> entries, long chunkNumRecords) {
+    int totalPayloadSize = entries.stream().mapToInt(e -> e.payload.length).sum();
+    ByteBuf bb = Utils.byteBufAllocator().buffer(64 + totalPayloadSize + 16 * entries.size());
+    bb.writeShort(Utils.encodeRequestCode(Constants.COMMAND_DELIVER))
+        .writeShort(Constants.VERSION_1)
+        .writeByte(1) // subscription id
+        .writeByte(1) // magic and version
+        .writeByte(0) // chunk type
+        .writeShort(entries.size()) // num entries
+        .writeInt((int) chunkNumRecords) // num records
+        .writeLong(System.currentTimeMillis())
+        .writeLong(0) // epoch
+        .writeLong(0) // offset
+        .writeInt(0) // CRC, unchecked with ChunkChecksum.NO_OP
+        .writeInt(0) // data length, unused with ChunkChecksum.NO_OP
+        .writeInt(0) // trailer length
+        .writeInt(0); // 4 reserved bytes
+
+    for (SubBatchEntry entry : entries) {
+      byte entryType = (byte) (0x80 | (entry.compressionCode << 4));
+      bb.writeByte(entryType)
+          .writeShort(entry.numRecordsInBatch)
+          .writeInt(entry.uncompressedDataSize)
+          .writeInt(entry.payload.length)
+          .writeBytes(entry.payload);
+    }
+    return bb;
+  }
+
+  // builds a chunk containing a single sub-batch entry, using the header fields under test
+  private static ByteBuf buildChunk(
+      byte compressionCode,
+      int declaredNumRecordsInBatch,
+      int declaredUncompressedDataSize,
+      byte[] entryPayload,
+      long chunkNumRecords) {
+    return buildChunk(
+        List.of(
+            new SubBatchEntry(
+                compressionCode,
+                declaredNumRecordsInBatch,
+                declaredUncompressedDataSize,
+                entryPayload)),
+        chunkNumRecords);
+  }
+
+  private static byte[] randomBytes(int size, long seed) {
+    byte[] bytes = new byte[size];
+    new Random(seed).nextBytes(bytes);
+    return bytes;
+  }
+
+  private static final class CompressedPayload {
+    final byte[] bytes;
+    final int uncompressedSize;
+    final int recordCount;
+
+    CompressedPayload(byte[] bytes, int uncompressedSize, int recordCount) {
+      this.bytes = bytes;
+      this.uncompressedSize = uncompressedSize;
+      this.recordCount = recordCount;
+    }
+  }
+
+  private static CompressedPayload compress(
+      CompressionCodec codec, int messageCount, int messageSize) {
+    ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+    CompressedEncodedMessageBatch batch =
+        new CompressedEncodedMessageBatch(allocator, codec, messageCount);
+    for (int i = 0; i < messageCount; i++) {
+      byte[] body = randomBytes(messageSize, i);
+      batch.add(new ByteArrayEncodedMessage(body.length, body));
+    }
+    batch.close();
+    int uncompressedSize = batch.uncompressedSizeInBytes();
+    ByteBuf out = allocator.buffer(batch.sizeInBytes());
+    batch.write(out);
+    byte[] bytes = new byte[out.readableBytes()];
+    out.readBytes(bytes);
+    out.release();
+    return new CompressedPayload(bytes, uncompressedSize, messageCount);
+  }
+
+  // identical bodies compress at a much higher ratio than varying ones, which is what makes the
+  // v1.9.0 MAX_COMPRESSION_RATIO guard reject legitimate repetitive traffic (heartbeats, etc.)
+  private static CompressedPayload compressIdentical(
+      CompressionCodec codec, int messageCount, int messageSize) {
+    ByteBufAllocator allocator = ByteBufAllocator.DEFAULT;
+    CompressedEncodedMessageBatch batch =
+        new CompressedEncodedMessageBatch(allocator, codec, messageCount);
+    byte[] body = randomBytes(messageSize, 42);
+    for (int i = 0; i < messageCount; i++) {
+      batch.add(new ByteArrayEncodedMessage(body.length, body));
+    }
+    batch.close();
+    int uncompressedSize = batch.uncompressedSizeInBytes();
+    ByteBuf out = allocator.buffer(batch.sizeInBytes());
+    batch.write(out);
+    byte[] bytes = new byte[out.readableBytes()];
+    out.readBytes(bytes);
+    out.release();
+    return new CompressedPayload(bytes, uncompressedSize, messageCount);
+  }
+
+  // counts and records the heap buffers requested through heapBuffer(initialCapacity,
+  // maxCapacity), so tests can assert on allocation sizing and on release
+  private static final class RecordingByteBufAllocator extends AbstractByteBufAllocator {
+
+    final List<int[]> requests = new ArrayList<>();
+    final List<ByteBuf> buffers = new ArrayList<>();
+
+    RecordingByteBufAllocator() {
+      super(false);
+    }
+
+    @Override
+    protected ByteBuf newHeapBuffer(int initialCapacity, int maxCapacity) {
+      requests.add(new int[] {initialCapacity, maxCapacity});
+      ByteBuf buffer = UnpooledByteBufAllocator.DEFAULT.heapBuffer(initialCapacity, maxCapacity);
+      buffers.add(buffer);
+      return buffer;
+    }
+
+    @Override
+    protected ByteBuf newDirectBuffer(int initialCapacity, int maxCapacity) {
+      return UnpooledByteBufAllocator.DEFAULT.directBuffer(initialCapacity, maxCapacity);
+    }
+
+    @Override
+    public boolean isDirectBufferPooled() {
+      return false;
+    }
+  }
+
+  private void deliver(ByteBuf bb, ChannelHandlerContext ctx, AtomicInteger messageCount) {
+    bb.readShort(); // command key
+    bb.readShort(); // command version
+    DeliverVersion1FrameHandler.handleDeliverVersion1(
+        bb,
+        client,
+        ctx,
+        (client, subscriptionId, offset, count, sizeOfData) -> null,
+        (subscriptionId, offset, chunkTimestamp, committedChunkId, chunkContext, message) ->
+            messageCount.incrementAndGet(),
+        (subscriptionId, offset, chunkTimestamp, committedChunkId, chunkContext) -> {},
+        NO_OP_CODEC,
+        ChunkChecksum.NO_OP,
+        NoOpMetricsCollector.SINGLETON);
+  }
+
+  @Test
+  void zeroUncompressedSizeMustThrow() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 5, 20);
+    ByteBuf bb =
+        buildChunk(
+            Compression.GZIP.code(),
+            payload.recordCount,
+            0, // declares 0 uncompressed bytes
+            payload.bytes,
+            payload.recordCount);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    assertTimeoutPreemptively(
+        Duration.ofSeconds(5),
+        () ->
+            assertThatThrownBy(() -> deliver(bb, ctx, new AtomicInteger()))
+                .isInstanceOf(StreamException.class));
+    bb.release();
+  }
+
+  @Test
+  void decompressedDataExceedingDeclaredSizeMustThrowAndStayBounded() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 200, 50);
+    int declaredUncompressedSize = payload.uncompressedSize / 2; // declares half the truth
+    ByteBuf bb =
+        buildChunk(
+            Compression.GZIP.code(),
+            payload.recordCount,
+            declaredUncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    RecordingByteBufAllocator allocator = new RecordingByteBufAllocator();
+    ChannelHandlerContext ctx = mockContext(allocator);
+
+    assertThatThrownBy(() -> deliver(bb, ctx, new AtomicInteger()))
+        .isInstanceOf(StreamException.class);
+
+    assertThat(allocator.requests).hasSize(1);
+    assertThat(allocator.requests.get(0)[1]).isEqualTo(declaredUncompressedSize);
+    assertThat(allocator.buffers.get(0).refCnt()).isZero();
+    bb.release();
+  }
+
+  @Test
+  void overDeclaredSizeMustOnlyAllocateInitialBufferSize() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 10, 50);
+    int declaredUncompressedSize = payload.bytes.length * 1024; // declares far more than the truth
+    ByteBuf bb =
+        buildChunk(
+            Compression.GZIP.code(),
+            payload.recordCount,
+            declaredUncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    RecordingByteBufAllocator allocator = new RecordingByteBufAllocator();
+    ChannelHandlerContext ctx = mockContext(allocator);
+    AtomicInteger messageCount = new AtomicInteger();
+
+    assertThatCode(() -> deliver(bb, ctx, messageCount)).doesNotThrowAnyException();
+
+    assertThat(messageCount).hasValue(payload.recordCount);
+    assertThat(allocator.requests).hasSize(1);
+    assertThat(allocator.requests.get(0)[0])
+        .isEqualTo(ServerFrameHandler.INITIAL_DECOMPRESSION_BUFFER_SIZE);
+    assertThat(allocator.requests.get(0)[1]).isEqualTo(declaredUncompressedSize);
+    assertThat(allocator.buffers.get(0).refCnt()).isZero();
+    bb.release();
+  }
+
+  @Test
+  void corruptMessageInSubBatchMustReleaseDecompressionBuffer() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 5, 20);
+    ByteBuf bb =
+        buildChunk(
+            Compression.GZIP.code(),
+            payload.recordCount,
+            payload.uncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    RecordingByteBufAllocator allocator = new RecordingByteBufAllocator();
+    ChannelHandlerContext ctx = mockContext(allocator);
+    bb.readShort(); // command key
+    bb.readShort(); // command version
+
+    Codec corruptCodec =
+        new Codec() {
+          @Override
+          public EncodedMessage encode(Message message) {
+            return null;
+          }
+
+          @Override
+          public Message decode(ByteBuf buf, int length) {
+            buf.skipBytes(length);
+            throw new StreamException("corrupt message rejected");
+          }
+
+          @Override
+          public MessageBuilder messageBuilder() {
+            return null;
+          }
+        };
+
+    assertThatThrownBy(
+            () ->
+                DeliverVersion1FrameHandler.handleDeliverVersion1(
+                    bb,
+                    client,
+                    ctx,
+                    (client, subscriptionId, offset, count, sizeOfData) -> null,
+                    (subscriptionId,
+                        offset,
+                        chunkTimestamp,
+                        committedChunkId,
+                        chunkContext,
+                        message) -> {},
+                    (subscriptionId, offset, chunkTimestamp, committedChunkId, chunkContext) -> {},
+                    corruptCodec,
+                    ChunkChecksum.NO_OP,
+                    NoOpMetricsCollector.SINGLETON))
+        .isInstanceOf(StreamException.class);
+
+    assertThat(allocator.requests).hasSize(1);
+    assertThat(allocator.buffers.get(0).refCnt()).isZero();
+    bb.release();
+  }
+
+  @Test
+  void recordCountLargerThanDecompressedDataMustThrowStreamException() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 5, 20);
+    int bogusRecordCount = 1000; // more than the decompressed data (5 records) can hold
+    ByteBuf bb =
+        buildChunk(
+            Compression.GZIP.code(),
+            bogusRecordCount,
+            payload.uncompressedSize,
+            payload.bytes,
+            bogusRecordCount);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    assertThatThrownBy(() -> deliver(bb, ctx, new AtomicInteger()))
+        .isInstanceOf(StreamException.class)
+        .hasMessageContaining("Invalid declared count");
+    bb.release();
+  }
+
+  @Test
+  void declaredSizeJustBelowCapIsAccepted() {
+    int maxUncompressedSize = 10_000;
+    when(client.maxUncompressedSubEntryBatchSize()).thenReturn(maxUncompressedSize);
+    byte[] payload = new byte[100];
+    ByteBuf bb = buildChunk(Compression.NONE.code(), 1, maxUncompressedSize - 1, payload, 1);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    assertThatCode(() -> deliver(bb, ctx, new AtomicInteger())).doesNotThrowAnyException();
+    bb.release();
+  }
+
+  @Test
+  void declaredSizeJustAboveCapIsRejected() {
+    int maxUncompressedSize = 10_000;
+    when(client.maxUncompressedSubEntryBatchSize()).thenReturn(maxUncompressedSize);
+    byte[] payload = new byte[100];
+    ByteBuf bb = buildChunk(Compression.NONE.code(), 1, maxUncompressedSize + 1, payload, 1);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    assertThatThrownBy(() -> deliver(bb, ctx, new AtomicInteger()))
+        .isInstanceOf(StreamException.class)
+        .hasMessageContaining("Uncompressed sub-entry batch size");
+    bb.release();
+  }
+
+  @Test
+  void capIsConfigurable() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 50, 50);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    when(client.maxUncompressedSubEntryBatchSize()).thenReturn(payload.uncompressedSize + 1);
+    ByteBuf accepted =
+        buildChunk(
+            Compression.GZIP.code(),
+            payload.recordCount,
+            payload.uncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    assertThatCode(() -> deliver(accepted, ctx, new AtomicInteger())).doesNotThrowAnyException();
+    accepted.release();
+
+    when(client.maxUncompressedSubEntryBatchSize()).thenReturn(payload.uncompressedSize - 1);
+    ByteBuf rejected =
+        buildChunk(
+            Compression.GZIP.code(),
+            payload.recordCount,
+            payload.uncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    assertThatThrownBy(() -> deliver(rejected, ctx, new AtomicInteger()))
+        .isInstanceOf(StreamException.class)
+        .hasMessageContaining("maxUncompressedSubEntryBatchSize");
+    rejected.release();
+  }
+
+  @Test
+  void ratioRegressionHighCompressionRatioIsAccepted() throws Exception {
+    // the v1.9.0 bug: a legitimate, highly compressible batch rejected by MAX_COMPRESSION_RATIO
+    useCompressionCodec(new ZstdJniCompressionCodec());
+    CompressedPayload payload = compressIdentical(new ZstdJniCompressionCodec(), 5000, 60);
+    assertThat(payload.uncompressedSize).isGreaterThan(payload.bytes.length * 2000);
+    ByteBuf bb =
+        buildChunk(
+            Compression.ZSTD.code(),
+            payload.recordCount,
+            payload.uncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+    AtomicInteger messageCount = new AtomicInteger();
+
+    assertThatCode(() -> deliver(bb, ctx, messageCount)).doesNotThrowAnyException();
+
+    assertThat(messageCount).hasValue(payload.recordCount);
+    bb.release();
+  }
+
+  @Test
+  void chunkBudgetAcceptsJustUnderAndRejectsJustOver() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 1, 5);
+    when(client.maxUncompressedSizePerChunk()).thenReturn(1000);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    List<SubBatchEntry> underBudget =
+        List.of(
+            new SubBatchEntry(Compression.GZIP.code(), payload.recordCount, 499, payload.bytes),
+            new SubBatchEntry(Compression.GZIP.code(), payload.recordCount, 499, payload.bytes));
+    ByteBuf accepted = buildChunk(underBudget, 2L * payload.recordCount);
+    assertThatCode(() -> deliver(accepted, ctx, new AtomicInteger())).doesNotThrowAnyException();
+    accepted.release();
+
+    // asserts the budget is per chunk, not accumulated across calls
+    ByteBuf acceptedAgain = buildChunk(underBudget, 2L * payload.recordCount);
+    assertThatCode(() -> deliver(acceptedAgain, ctx, new AtomicInteger()))
+        .doesNotThrowAnyException();
+    acceptedAgain.release();
+
+    List<SubBatchEntry> overBudget =
+        List.of(
+            new SubBatchEntry(Compression.GZIP.code(), payload.recordCount, 501, payload.bytes),
+            new SubBatchEntry(Compression.GZIP.code(), payload.recordCount, 501, payload.bytes));
+    ByteBuf rejected = buildChunk(overBudget, 2L * payload.recordCount);
+    assertThatThrownBy(() -> deliver(rejected, ctx, new AtomicInteger()))
+        .isInstanceOf(StreamException.class)
+        .hasMessageContaining("maxUncompressedSizePerChunk");
+    rejected.release();
+  }
+
+  @Test
+  void budgetCheckedBeforeAllocatingBuffer() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 1, 5);
+    when(client.maxUncompressedSizePerChunk()).thenReturn(10);
+    ByteBuf bb =
+        buildChunk(
+            Compression.GZIP.code(), payload.recordCount, 500, payload.bytes, payload.recordCount);
+    RecordingByteBufAllocator allocator = new RecordingByteBufAllocator();
+    ChannelHandlerContext ctx = mockContext(allocator);
+
+    assertThatThrownBy(() -> deliver(bb, ctx, new AtomicInteger()))
+        .isInstanceOf(StreamException.class)
+        .hasMessageContaining("maxUncompressedSizePerChunk");
+
+    assertThat(allocator.requests).isEmpty();
+    bb.release();
+  }
+
+  @Test
+  void noneEntriesDoNotConsumeBudget() {
+    when(client.maxUncompressedSizePerChunk()).thenReturn(100);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+    byte[] zeroLengthRecord = new byte[4]; // a single record whose entrySize is 0
+
+    List<SubBatchEntry> entries =
+        List.of(
+            new SubBatchEntry(Compression.NONE.code(), 1, 1000, zeroLengthRecord),
+            new SubBatchEntry(Compression.NONE.code(), 1, 1000, zeroLengthRecord));
+    ByteBuf bb = buildChunk(entries, 2);
+
+    assertThatCode(() -> deliver(bb, ctx, new AtomicInteger())).doesNotThrowAnyException();
+    bb.release();
+  }
+
+  @Test
+  void zeroRecordSubBatchIsAcceptedNotRejected() throws Exception {
+    useCompressionCodec(new GzipCompressionCodec());
+    CompressedPayload payload = compress(new GzipCompressionCodec(), 0, 20);
+    ByteBuf bb = buildChunk(Compression.GZIP.code(), 0, payload.uncompressedSize, payload.bytes, 0);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+
+    assertThatCode(() -> deliver(bb, ctx, new AtomicInteger())).doesNotThrowAnyException();
+    bb.release();
+  }
+
+  static List<CompressionCodec> codecs() {
+    CompressionCodecFactory factory = new DefaultCompressionCodecFactory();
+    return Arrays.stream(Compression.values())
+        .filter(c -> c != Compression.NONE)
+        .map(factory::get)
+        .collect(Collectors.toList());
+  }
+
+  @ParameterizedTest
+  @MethodSource("codecs")
+  void decompressionBufferGrowsPastInitialCapacityForLargeBatches(CompressionCodec codec)
+      throws Exception {
+    useCompressionCodec(codec);
+    CompressedPayload payload = compress(codec, 2000, 50);
+    assertThat(payload.uncompressedSize)
+        .isGreaterThan(ServerFrameHandler.INITIAL_DECOMPRESSION_BUFFER_SIZE);
+    ByteBuf bb =
+        buildChunk(
+            codec.code(),
+            payload.recordCount,
+            payload.uncompressedSize,
+            payload.bytes,
+            payload.recordCount);
+    ChannelHandlerContext ctx = mockContext(UnpooledByteBufAllocator.DEFAULT);
+    AtomicInteger messageCount = new AtomicInteger();
+
+    assertThatCode(() -> deliver(bb, ctx, messageCount)).doesNotThrowAnyException();
+
+    assertThat(messageCount).hasValue(payload.recordCount);
+    bb.release();
+  }
+}


### PR DESCRIPTION
Cap the max size of a decompressed sub-entry with `maxUncompressedSubEntryBatchSize` (64 MB by default). This limits the memory allocation during dispatching.

Cap the max decompressed size inside a given chunk with `maxUncompressedSizePerChunk` (default to 1 GB). This limits the decompression work.