### PR TITLE
build(deps): exclude unused transitive Netty sub-modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,20 @@
       <groupId>io.netty</groupId>
       <artifactId>netty-codec</artifactId>
       <version>${netty.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-compression</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-protobuf</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec-marshalling</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Exclude netty-codec-compression, netty-codec-protobuf, and netty-codec-marshalling from netty-codec dependency. Only basic frame decoders are required, reducing the transitive artifact footprint for library consumers.