### PR TITLE
fix(network): bump default frame max to 20 MiB

### DIFF
--- a/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
+++ b/src/main/java/com/rabbitmq/stream/EnvironmentBuilder.java
@@ -201,7 +201,7 @@ public interface EnvironmentBuilder {
   /**
    * The maximum frame size to request.
    *
-   * <p>Default is 1048576.
+   * <p>Default is 20971520 (20 MiB).
    *
    * @param requestedMaxFrameSize
    * @return this builder instance

--- a/src/main/java/com/rabbitmq/stream/impl/Client.java
+++ b/src/main/java/com/rabbitmq/stream/impl/Client.java
@@ -169,7 +169,7 @@ public class Client implements AutoCloseable {
   public static final int DEFAULT_PORT = 5552;
   public static final int DEFAULT_TLS_PORT = 5551;
   static final int MAX_REFERENCE_SIZE = 256;
-  static final int DEFAULT_MAX_FRAME_SIZE = 1048576;
+  static final int DEFAULT_MAX_FRAME_SIZE = 20971520; // 20 MiB
   // used before the max frame size is negotiated with the server (tune/open exchange), so the
   // client is never exposed to an unbounded or overly large frame from an unauthenticated peer
   static final int DEFAULT_MAX_FRAME_SIZE_BEFORE_AUTHENTICATION = 8192;


### PR DESCRIPTION
From 1 MiB. To align with the new broker default (RabbitMQ 4.3.5).

References https://github.com/rabbitmq/rabbitmq-server/pull/17126